### PR TITLE
Split up grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,22 +33,7 @@ module.exports = function (grunt) {
       client: require('./bower.json').appPath || 'client',
       dist: 'dist'
     },
-    express: {
-      options: {
-        port: process.env.PORT || 9000
-      },
-      dev: {
-        options: {
-          script: 'server/app.js',
-          debug: true
-        }
-      },
-      prod: {
-        options: {
-          script: 'dist/server/app.js'
-        }
-      }
-    },
+
     open: {
       server: {
         url: 'http://localhost:<%= express.options.port %>'
@@ -175,71 +160,6 @@ module.exports = function (grunt) {
       }
     },
 
-    // Make sure code styles are up to par and there are no obvious mistakes
-    jshint: {
-      options: {
-        jshintrc: '<%= yeoman.client %>/.jshintrc',
-        reporter: require('jshint-stylish')
-      },
-      server: {
-        options: {
-          jshintrc: 'server/.jshintrc'
-        },
-        src: [
-          'server/**/*.js',
-          '!server/**/*.spec.js'
-        ]
-      },
-      serverTest: {
-        options: {
-          jshintrc: 'server/.jshintrc-spec'
-        },
-        src: ['server/**/*.spec.js']
-      },
-      all: [
-        '<%= yeoman.client %>/{app,components}/**/*.js',
-        '!<%= yeoman.client %>/{app,components}/**/*.spec.js',
-        '!<%= yeoman.client %>/{app,components}/**/*.mock.js'
-      ],
-      test: {
-        src: [
-          '<%= yeoman.client %>/{app,components}/**/*.spec.js',
-          '<%= yeoman.client %>/{app,components}/**/*.mock.js'
-        ]
-      }
-    },
-
-    // Empties folders to start fresh
-    clean: {
-      dist: {
-        files: [{
-          dot: true,
-          src: [
-            '.tmp',
-            '<%= yeoman.dist %>/*',
-            '!<%= yeoman.dist %>/.git*',
-            '!<%= yeoman.dist %>/.openshift',
-            '!<%= yeoman.dist %>/Procfile'
-          ]
-        }]
-      },
-      server: '.tmp'
-    },
-
-    // Add vendor prefixed styles
-    autoprefixer: {
-      options: {
-        browsers: ['last 1 version']
-      },
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/',
-          src: '{,*/}*.css',
-          dest: '.tmp/'
-        }]
-      }
-    },
 
     // Debugging with node inspector
     'node-inspector': {
@@ -299,98 +219,6 @@ module.exports = function (grunt) {
       }
     },
 
-    // Reads HTML for usemin blocks to enable smart builds that automatically
-    // concat, minify and revision files. Creates configurations in memory so
-    // additional tasks can operate on them
-    useminPrepare: {
-      html: ['server/views/index.html'],
-      options: {
-        dest: '<%= yeoman.dist %>/public'
-      }
-    },
-
-    // Performs rewrites based on rev and the useminPrepare configuration
-    usemin: {
-      html: ['<%= yeoman.dist %>/server/views/{,*/}*.html'],
-      css: ['<%= yeoman.dist %>/public/{,*/}*.css'],
-      js: ['<%= yeoman.dist %>/public/{,*/}*.js'],
-      options: {
-        assetsDirs: [
-          '<%= yeoman.dist %>/public',
-          '<%= yeoman.dist %>/public/assets/images'
-        ],
-        // This is so we update image references in our ng-templates
-        patterns: {
-          js: [
-            [/(assets\/images\/.*?\.(?:gif|jpeg|jpg|png|webp|svg))/gm, 'Update the JS to reference our revved images']
-          ]
-        }
-      }
-    },
-
-    // The following *-min tasks produce minified files in the dist folder
-    imagemin: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.client %>/assets/images',
-          src: '{,*/}*.{png,jpg,jpeg,gif}',
-          dest: '<%= yeoman.dist %>/public/assets/images'
-        }]
-      }
-    },
-
-    svgmin: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.client %>/assets/images',
-          src: '{,*/}*.svg',
-          dest: '<%= yeoman.dist %>/public/assets/images'
-        }]
-      }
-    },
-
-    // Allow the use of non-minsafe AngularJS files. Automatically makes it
-    // minsafe compatible so Uglify does not destroy the ng references
-    ngAnnotate: {
-      dist: {
-        files: [{
-          expand: true,
-          cwd: '.tmp/concat',
-          src: '*/**.js',
-          dest: '.tmp/concat'
-        }]
-      }
-    },
-
-    // Package all the html partials into a single javascript payload
-    ngtemplates: {
-      options: {
-        // This should be the name of your apps angular module
-        module: 'meanbaseApp',
-        htmlmin: {
-          collapseBooleanAttributes: true,
-          collapseWhitespace: true,
-          removeAttributeQuotes: true,
-          removeEmptyAttributes: true,
-          removeRedundantAttributes: true,
-          removeScriptTypeAttributes: true,
-          removeStyleLinkTypeAttributes: true
-        },
-        usemin: 'app/app.js'
-      },
-      main: {
-        cwd: '<%= yeoman.client %>',
-        src: ['{app,components}/**/*.html'],
-        dest: '.tmp/templates.js'
-      },
-      tmp: {
-        cwd: '.tmp',
-        src: ['{app,components}/**/*.html'],
-        dest: '.tmp/tmp-templates.js'
-      }
-    },
 
     // Replace Google CDN references
     cdnify: {
@@ -399,46 +227,6 @@ module.exports = function (grunt) {
       }
     },
 
-    // Copies remaining files to places other tasks can use
-    copy: {
-      noProcess: ['woff', 'woff2', 'ttf'],
-      dist: {
-        files: [{
-          expand: true,
-          dot: true,
-          cwd: '<%= yeoman.client %>',
-          dest: '<%= yeoman.dist %>/public',
-          src: [
-            '*.{ico,png,txt}',
-            '.htaccess',
-            'bower_components/**/*',
-            'assets/images/{,*/}*.{webp}',
-            'assets/fonts/**/*',
-            'themes/**/*',
-            'extensions/**/*',
-            'index.html'
-          ]
-        }, {
-          expand: true,
-          cwd: '.tmp/images',
-          dest: '<%= yeoman.dist %>/public/assets/images',
-          src: ['generated/*']
-        }, {
-          expand: true,
-          dest: '<%= yeoman.dist %>',
-          src: [
-            'package.json',
-            'server/**/*'
-          ]
-        }]
-      },
-      styles: {
-        expand: true,
-        cwd: '<%= yeoman.client %>',
-        dest: '.tmp/',
-        src: ['{app,components}/**/*.css']
-      }
-    },
 
     buildcontrol: {
       options: {
@@ -462,60 +250,10 @@ module.exports = function (grunt) {
       }
     },
 
-    // Run some tasks in parallel to speed up the build process
-    concurrent: {
-      server: [
-        'jade',
-        'stylus:cms'
-      ],
-      test: [
-        'jade',
-        'stylus:cms'
-      ],
-      debug: {
-        tasks: [
-          'nodemon',
-          'node-inspector'
-        ],
-        options: {
-          logConcurrentOutput: true
-        }
-      },
-      dist: [
-        'jade',
-        'stylus:cms',
-        'imagemin',
-        'svgmin'
-      ]
-    },
 
     // Test settings
-    karma: {
-      unit: {
-        configFile: 'karma.conf.js',
-        singleRun: true
-      }
-    },
+      // Karma, MochaTest and Protractor tasks are in grunt/testing.js
 
-    mochaTest: {
-      options: {
-        reporter: 'spec'
-      },
-      src: ['server/**/*.spec.js']
-    },
-
-    protractor: {
-      options: {
-        configFile: 'protractor.conf.js'
-      },
-      chrome: {
-        options: {
-          args: {
-            browser: 'chrome'
-          }
-        }
-      }
-    },
 
     env: {
       test: {
@@ -527,108 +265,6 @@ module.exports = function (grunt) {
       all: localConfig
     },
 
-    // Compiles Jade to html
-    jade: {
-      compile: {
-        options: {
-          data: {
-            debug: false
-          }
-        },
-        files: [{
-          expand: true,
-          cwd: '<%= yeoman.client %>',
-          src: [
-            '{app,components,themes,extensions}/**/*.jade'
-          ],
-          dest: '.tmp',
-          ext: '.html'
-        }]
-      }
-    },
-
-    // Compiles Stylus to CSS
-    stylus: {
-      cms: {
-        options: {
-          paths: [
-            '<%= yeoman.client %>/bower_components',
-            '<%= yeoman.client %>/app',
-            '<%= yeoman.client %>/components'
-          ],
-          "include css": true
-        },
-        files: {
-          '.tmp/app/app.css' : '<%= yeoman.client %>/app/app.styl'
-        }
-      }
-    },
-
-    injector: {
-      options: {
-
-      },
-      // Inject application script files into index.html (doesn't include bower)
-      scripts: {
-        options: {
-          transform: function(filePath) {
-            filePath = filePath.replace('/client/', '');
-            filePath = filePath.replace('/.tmp/', '');
-            return '<script src="' + filePath + '"></script>';
-          },
-          starttag: '<!-- injector:js -->',
-          endtag: '<!-- endinjector -->'
-        },
-        files: {
-          'server/views/index.html': [
-              ['{.tmp,<%= yeoman.client %>}/{app,components}/**/*.js',
-               '!{.tmp,<%= yeoman.client %>}/components/ckeditor/**/*.js',
-               '!{.tmp,<%= yeoman.client %>}/app/app.js',
-               '!{.tmp,<%= yeoman.client %>}/{app,components}/**/*.spec.js',
-               '!{.tmp,<%= yeoman.client %>}/{app,components}/**/*.mock.js']
-            ]
-        }
-      },
-
-      // Inject component styl into app.styl
-      stylus: {
-        options: {
-          transform: function(filePath) {
-            filePath = filePath.replace('/client/app/', '');
-            filePath = filePath.replace('/client/components/', '');
-            filePath = filePath.replace('/client', '..');
-            return '@import \'' + filePath + '\';';
-          },
-          starttag: '// injector',
-          endtag: '// endinjector'
-        },
-        files: {
-          '<%= yeoman.client %>/app/app.styl': [
-            '<%= yeoman.client %>/{app,components}/**/*.styl',
-            '!<%= yeoman.client %>/app/app.styl'
-          ]
-        }
-      },
-
-      // Inject component css into index.html
-      css: {
-        options: {
-          transform: function(filePath) {
-            filePath = filePath.replace('/client/', '');
-            filePath = filePath.replace('/.tmp/', '');
-            return '<link rel="stylesheet" href="' + filePath + '">';
-          },
-          starttag: '<!-- injector:css -->',
-          endtag: '<!-- endinjector -->'
-        },
-        files: {
-          'server/views/index.html': [
-            '<%= yeoman.client %>/{app,components}/**/*.css',
-            '!<%= yeoman.client %>/components/ckeditor/**/*.css'
-          ]
-        }
-      }
-    },
   });
 
   // Used for delaying livereload until after server has restarted
@@ -643,8 +279,8 @@ module.exports = function (grunt) {
     }, 1500);
   });
 
-
-
+  // Load tasks from the grunt folder
+  require('load-grunt-tasks')(grunt);
 
 
   // Add link each theme's assets into main file.

--- a/grunt/angular.js
+++ b/grunt/angular.js
@@ -1,0 +1,47 @@
+// This file should contain the tasks used for angular
+
+
+module.exports = function(grunt) {
+    
+// Allow the use of non-minsafe AngularJS files. Automatically makes it
+// minsafe compatible so Uglify does not destroy the ng references
+  	grunt.config('ngAnnotate', {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '.tmp/concat',
+          src: '*/**.js',
+          dest: '.tmp/concat'
+        }]
+      }
+   });
+
+// Package all the html partials into a single javascript payload
+  	grunt.config('ngtemplates', {
+      options: {
+        // This should be the name of your apps angular module
+        module: 'meanbaseApp',
+        htmlmin: {
+          collapseBooleanAttributes: true,
+          collapseWhitespace: true,
+          removeAttributeQuotes: true,
+          removeEmptyAttributes: true,
+          removeRedundantAttributes: true,
+          removeScriptTypeAttributes: true,
+          removeStyleLinkTypeAttributes: true
+        },
+        usemin: 'app/app.js'
+      },
+      main: {
+        cwd: '<%= yeoman.client %>',
+        src: ['{app,components}/**/*.html'],
+        dest: '.tmp/templates.js'
+      },
+      tmp: {
+        cwd: '.tmp',
+        src: ['{app,components}/**/*.html'],
+        dest: '.tmp/tmp-templates.js'
+      }
+   });
+
+};

--- a/grunt/autoprefixer.js
+++ b/grunt/autoprefixer.js
@@ -1,0 +1,18 @@
+module.exports = function(grunt) {
+
+  	grunt.config('autoprefixer', {
+		options: {
+			browsers: ['last 1 version']
+		},
+		dist: {
+			files: [{
+				expand: true,
+				cwd: '.tmp/',
+				src: '{,*/}*.css',
+				dest: '.tmp/'
+			}]
+		}
+   });
+
+
+};

--- a/grunt/clean.js
+++ b/grunt/clean.js
@@ -1,0 +1,20 @@
+module.exports = function(grunt) {
+
+  	grunt.config('clean', {
+    	dist: {
+	        files: [{
+	        	dot: true,
+	        	src: [
+		        	'.tmp',
+		        	'<%= yeoman.dist %>/*',
+		        	'!<%= yeoman.dist %>/.git*',
+		        	'!<%= yeoman.dist %>/.openshift',
+		        	'!<%= yeoman.dist %>/Procfile'
+	          	]
+	        }]
+      	},
+      server: '.tmp'
+   });
+
+
+};

--- a/grunt/concurrent.js
+++ b/grunt/concurrent.js
@@ -1,0 +1,30 @@
+module.exports = function(grunt) {
+// Run some tasks in parallel to speed up the build process
+  	grunt.config('concurrent', {
+      server: [
+        'jade',
+        'stylus:cms'
+      ],
+      test: [
+        'jade',
+        'stylus:cms'
+      ],
+      debug: {
+        tasks: [
+          'nodemon',
+          'node-inspector'
+        ],
+        options: {
+          logConcurrentOutput: true
+        }
+      },
+      dist: [
+        'jade',
+        'stylus:cms',
+        'imagemin',
+        'svgmin'
+      ]
+   });
+
+
+};

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -1,0 +1,45 @@
+module.exports = function(grunt) {
+	
+// Copies remaining files to places other tasks can use
+  	grunt.config('copy', {
+	      noProcess: ['woff', 'woff2', 'ttf'],
+	      dist: {
+	        files: [{
+	          expand: true,
+	          dot: true,
+	          cwd: '<%= yeoman.client %>',
+	          dest: '<%= yeoman.dist %>/public',
+	          src: [
+	            '*.{ico,png,txt}',
+	            '.htaccess',
+	            'bower_components/**/*',
+	            'assets/images/{,*/}*.{webp}',
+	            'assets/fonts/**/*',
+	            'themes/**/*',
+	            'extensions/**/*',
+	            'index.html'
+	          ]
+	        }, {
+	          expand: true,
+	          cwd: '.tmp/images',
+	          dest: '<%= yeoman.dist %>/public/assets/images',
+	          src: ['generated/*']
+	        }, {
+	          expand: true,
+	          dest: '<%= yeoman.dist %>',
+	          src: [
+	            'package.json',
+	            'server/**/*'
+	          ]
+	        }]
+	      },
+	      styles: {
+	        expand: true,
+	        cwd: '<%= yeoman.client %>',
+	        dest: '.tmp/',
+	        src: ['{app,components}/**/*.css']
+	      }
+   });
+
+
+};

--- a/grunt/express.js
+++ b/grunt/express.js
@@ -1,0 +1,21 @@
+module.exports = function(grunt) {
+
+  	grunt.config('express', {
+		options: {
+			port: process.env.PORT || 9000
+		},
+		dev: {
+			options: {
+		  		script: 'server/app.js',
+		  		debug: true
+			}
+		},
+		prod: {
+			options: {
+				script: 'dist/server/app.js'
+			}
+		}
+   });
+
+
+};

--- a/grunt/imagemin.js
+++ b/grunt/imagemin.js
@@ -1,0 +1,32 @@
+// This file should minimize all images
+
+
+module.exports = function(grunt) {
+
+// The following *-min tasks produce minified files in the dist folder
+  	grunt.config('imagemin', {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.client %>/assets/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '<%= yeoman.dist %>/public/assets/images'
+        }]
+      }
+   });
+
+// For SVG's
+  	grunt.config('svgmin', {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.client %>/assets/images',
+          src: '{,*/}*.svg',
+          dest: '<%= yeoman.dist %>/public/assets/images'
+        }]
+      }
+
+   });
+
+
+};

--- a/grunt/injector.js
+++ b/grunt/injector.js
@@ -1,0 +1,71 @@
+module.exports = function(grunt) {
+
+  	grunt.config('injector', {
+      options: {
+
+      },
+      // Inject application script files into index.html (doesn't include bower)
+      scripts: {
+        options: {
+          transform: function(filePath) {
+            filePath = filePath.replace('/client/', '');
+            filePath = filePath.replace('/.tmp/', '');
+            return '<script src="' + filePath + '"></script>';
+          },
+          starttag: '<!-- injector:js -->',
+          endtag: '<!-- endinjector -->'
+        },
+        files: {
+          'server/views/index.html': [
+              ['{.tmp,<%= yeoman.client %>}/{app,components}/**/*.js',
+               '!{.tmp,<%= yeoman.client %>}/components/ckeditor/**/*.js',
+               '!{.tmp,<%= yeoman.client %>}/app/app.js',
+               '!{.tmp,<%= yeoman.client %>}/{app,components}/**/*.spec.js',
+               '!{.tmp,<%= yeoman.client %>}/{app,components}/**/*.mock.js']
+            ]
+        }
+      },
+
+      // Inject component styl into app.styl
+      stylus: {
+        options: {
+          transform: function(filePath) {
+            filePath = filePath.replace('/client/app/', '');
+            filePath = filePath.replace('/client/components/', '');
+            filePath = filePath.replace('/client', '..');
+            return '@import \'' + filePath + '\';';
+          },
+          starttag: '// injector',
+          endtag: '// endinjector'
+        },
+        files: {
+          '<%= yeoman.client %>/app/app.styl': [
+            '<%= yeoman.client %>/{app,components}/**/*.styl',
+            '!<%= yeoman.client %>/app/app.styl'
+          ]
+        }
+      },
+
+      // Inject component css into index.html
+      css: {
+        options: {
+          transform: function(filePath) {
+            filePath = filePath.replace('/client/', '');
+            filePath = filePath.replace('/.tmp/', '');
+            return '<link rel="stylesheet" href="' + filePath + '">';
+          },
+          starttag: '<!-- injector:css -->',
+          endtag: '<!-- endinjector -->'
+        },
+        files: {
+          'server/views/index.html': [
+            '<%= yeoman.client %>/{app,components}/**/*.css',
+            '!<%= yeoman.client %>/components/ckeditor/**/*.css'
+          ]
+        }
+      }
+
+   });
+
+
+};

--- a/grunt/jade.js
+++ b/grunt/jade.js
@@ -1,0 +1,23 @@
+module.exports = function(grunt) {
+    // Compiles Jade to html
+  	grunt.config('jade', {
+      compile: {
+        options: {
+          data: {
+            debug: false
+          }
+        },
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.client %>',
+          src: [
+            '{app,components,themes,extensions}/**/*.jade'
+          ],
+          dest: '.tmp',
+          ext: '.html'
+        }]
+      }
+   });
+
+
+};

--- a/grunt/jshint.js
+++ b/grunt/jshint.js
@@ -1,0 +1,39 @@
+module.exports = function(grunt) {
+
+// Make sure code styles are up to par and there are no obvious mistakes
+  	grunt.config('jshint', {
+      options: {
+        jshintrc: '<%= yeoman.client %>/.jshintrc',
+        reporter: require('jshint-stylish')
+      },
+      server: {
+        options: {
+          jshintrc: 'server/.jshintrc'
+        },
+        src: [
+          'server/**/*.js',
+          '!server/**/*.spec.js'
+        ]
+      },
+      serverTest: {
+        options: {
+          jshintrc: 'server/.jshintrc-spec'
+        },
+        src: ['server/**/*.spec.js']
+      },
+      all: [
+        '<%= yeoman.client %>/{app,components}/**/*.js',
+        '!<%= yeoman.client %>/{app,components}/**/*.spec.js',
+        '!<%= yeoman.client %>/{app,components}/**/*.mock.js'
+      ],
+      test: {
+        src: [
+          '<%= yeoman.client %>/{app,components}/**/*.spec.js',
+          '<%= yeoman.client %>/{app,components}/**/*.mock.js'
+        ]
+      }
+
+   });
+
+
+};

--- a/grunt/stylus.js
+++ b/grunt/stylus.js
@@ -1,0 +1,20 @@
+module.exports = function(grunt) {
+// Compiles Stylus to CSS
+  	grunt.config('stylus', {
+      cms: {
+        options: {
+          paths: [
+            '<%= yeoman.client %>/bower_components',
+            '<%= yeoman.client %>/app',
+            '<%= yeoman.client %>/components'
+          ],
+          "include css": true
+        },
+        files: {
+          '.tmp/app/app.css' : '<%= yeoman.client %>/app/app.styl'
+        }
+      }
+   });
+
+
+};

--- a/grunt/testing.js
+++ b/grunt/testing.js
@@ -1,0 +1,32 @@
+module.exports = function(grunt) {
+
+  grunt.config('karma', {
+      unit: {
+        configFile: 'karma.conf.js',
+        singleRun: true
+      }
+  });
+
+
+  grunt.config('mochaTest', {
+      options: {
+        reporter: 'spec'
+      },
+      src: ['server/**/*.spec.js']
+  });
+
+  
+  grunt.config('protractor', {
+      options: {
+        configFile: 'protractor.conf.js'
+      },
+      chrome: {
+        options: {
+          args: {
+            browser: 'chrome'
+          }
+        }
+      }
+  });
+
+};

--- a/grunt/usemin.js
+++ b/grunt/usemin.js
@@ -1,0 +1,37 @@
+module.exports = function(grunt) {
+
+// Reads HTML for usemin blocks to enable smart builds that automatically
+// concat, minify and revision files. Creates configurations in memory so
+// additional tasks can operate on them
+	grunt.config('useminPrepare', {
+      html: ['server/views/index.html'],
+      options: {
+        dest: '<%= yeoman.dist %>/public'
+      }
+   });
+
+
+// Performs rewrites based on rev and the useminPrepare configuration
+  	grunt.config('usemin', {
+    	
+    	html: ['<%= yeoman.dist %>/server/views/{,*/}*.html'],
+    	css: ['<%= yeoman.dist %>/public/{,*/}*.css'],
+    	js: ['<%= yeoman.dist %>/public/{,*/}*.js'],
+    	
+    	options: {
+	        assetsDirs: [
+	        	'<%= yeoman.dist %>/public',
+	        	'<%= yeoman.dist %>/public/assets/images'
+	        ],
+	        // This is so we update image references in our ng-templates
+	        patterns: {
+	          js: [
+	            [/(assets\/images\/.*?\.(?:gif|jpeg|jpg|png|webp|svg))/gm, 'Update the JS to reference our revved images']
+	          ]
+	        }
+      	}
+
+   });
+
+
+};

--- a/grunt/watch.js
+++ b/grunt/watch.js
@@ -1,0 +1,77 @@
+module.exports = function(grunt) {
+
+  	grunt.config('watch', {
+		injectJS: {
+			files: [
+				'<%= yeoman.client %>/{app,components}/**/*.js',
+				'!<%= yeoman.client %>/{app,components}/**/*.spec.js',
+				'!<%= yeoman.client %>/{app,components}/**/*.mock.js',
+				'!<%= yeoman.client %>/app/app.js'],
+			tasks: ['injector:scripts']
+		},
+		injectCss: {
+			files: ['<%= yeoman.client %>/{app,components}/**/*.css'],
+			tasks: ['injector:css']
+		},
+		compileThemeAssets: {
+			files: [
+			  '<%= yeoman.client %>/themes/**/*.css',
+			  '<%= yeoman.client %>/themes/**/*.js',
+			  '<%= yeoman.client %>/themes/**/*.styl',
+			  '!<%= yeoman.client %>/themes/**/theme.css'
+			],
+			tasks: ['compile-theme-assets']
+		},
+		mochaTest: {
+			files: ['server/**/*.spec.js'],
+			tasks: ['env:test', 'mochaTest']
+		},
+		jsTest: {
+			files: [
+			  '<%= yeoman.client %>/{app,components}/**/*.spec.js',
+			  '<%= yeoman.client %>/{app,components}/**/*.mock.js'
+			],
+			tasks: ['newer:jshint:all', 'karma']
+		},
+		injectStylus: {
+			files: ['<%= yeoman.client %>/{app,components}/**/*.styl'],
+			tasks: ['injector:stylus']
+		},
+		stylus: {
+			files: ['<%= yeoman.client %>/{app,components}/**/*.styl'],
+			tasks: ['stylus:cms', 'autoprefixer']
+		},
+		jade: {
+			files: [
+			  '<%= yeoman.client %>/{app,components,themes,extensions}/*',
+			  '<%= yeoman.client %>/{app,components,themes,extensions}/**/*.jade'],
+			tasks: ['jade']
+		},
+		gruntfile: {
+			files: ['Gruntfile.js']
+		},
+		livereload: {
+			files: [
+			  '{.tmp,<%= yeoman.client %>}/{app,components}/**/*.css',
+			  '{.tmp,<%= yeoman.client %>}/{app,components}/**/*.html',
+			  '{.tmp,<%= yeoman.client %>}/{app,components}/**/*.js',
+			  '!{.tmp,<%= yeoman.client %>}{app,components}/**/*.spec.js',
+			  '!{.tmp,<%= yeoman.client %>}/{app,components}/**/*.mock.js',
+			  '<%= yeoman.client %>/assets/images/{,*//*}*.{png,jpg,jpeg,gif,webp,svg}'
+			],
+			options: {
+			  livereload: true
+			}
+		},
+		express: {
+			files: ['server/**/*.{js,json}'],
+			tasks: ['express:dev', 'wait'],
+			options: {
+			  	livereload: true,
+			 	nospawn: true //Without this option specified express won't be reloaded
+			}
+		}	
+   });
+
+
+};

--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,7003 @@
+0 info it worked if it ends with ok
+1 verbose cli [ 'C:\\Program Files\\nodejs\\\\node.exe',
+1 verbose cli   'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
+1 verbose cli   'install' ]
+2 info using npm@2.7.4
+3 info using node@v0.12.2
+4 verbose node symlink C:\Program Files\nodejs\\node.exe
+5 verbose install where, deps [ 'C:\\Users\\Owner\\Documents\\GitHub\\FULLSTACK\\backend\\MEAN\\meanbase-1.0.0',
+5 verbose install   [ 'body-parser',
+5 verbose install     'chokidar',
+5 verbose install     'composable-middleware',
+5 verbose install     'compression',
+5 verbose install     'connect-mongo',
+5 verbose install     'cookie-parser',
+5 verbose install     'decompress',
+5 verbose install     'decompress-unzip',
+5 verbose install     'errorhandler',
+5 verbose install     'express',
+5 verbose install     'express-jwt',
+5 verbose install     'express-session',
+5 verbose install     'formidable',
+5 verbose install     'fs-extra',
+5 verbose install     'fs-finder',
+5 verbose install     'gm',
+5 verbose install     'jade',
+5 verbose install     'jade-browser-middleware',
+5 verbose install     'jsonwebtoken',
+5 verbose install     'lodash',
+5 verbose install     'method-override',
+5 verbose install     'mongoose',
+5 verbose install     'mongoose-text-search',
+5 verbose install     'mongoose-validators',
+5 verbose install     'morgan',
+5 verbose install     'multer',
+5 verbose install     'passport',
+5 verbose install     'passport-facebook',
+5 verbose install     'passport-google-oauth',
+5 verbose install     'passport-local',
+5 verbose install     'passport-twitter',
+5 verbose install     'prerender-node',
+5 verbose install     'promise',
+5 verbose install     'serve-favicon',
+5 verbose install     'winston',
+5 verbose install     'xml-to-json',
+5 verbose install     'connect-livereload',
+5 verbose install     'grunt',
+5 verbose install     'grunt-angular-templates',
+5 verbose install     'grunt-asset-injector',
+5 verbose install     'grunt-autoprefixer',
+5 verbose install     'grunt-build-control',
+5 verbose install     'grunt-concurrent',
+5 verbose install     'grunt-contrib-clean',
+5 verbose install     'grunt-contrib-copy',
+5 verbose install     'grunt-contrib-cssmin',
+5 verbose install     'grunt-contrib-htmlmin',
+5 verbose install     'grunt-contrib-imagemin',
+5 verbose install     'grunt-contrib-jade',
+5 verbose install     'grunt-contrib-jshint',
+5 verbose install     'grunt-contrib-stylus',
+5 verbose install     'grunt-contrib-uglify',
+5 verbose install     'grunt-contrib-watch',
+5 verbose install     'grunt-docco',
+5 verbose install     'grunt-docker',
+5 verbose install     'grunt-dom-munger',
+5 verbose install     'grunt-env',
+5 verbose install     'grunt-express-server',
+5 verbose install     'grunt-google-cdn',
+5 verbose install     'grunt-karma',
+5 verbose install     'grunt-mocha-test',
+5 verbose install     'grunt-newer',
+5 verbose install     'grunt-ng-annotate',
+5 verbose install     'grunt-node-inspector',
+5 verbose install     'grunt-nodemon',
+5 verbose install     'grunt-open',
+5 verbose install     'grunt-protractor-runner',
+5 verbose install     'grunt-rev',
+5 verbose install     'grunt-svgmin',
+5 verbose install     'grunt-usemin',
+5 verbose install     'grunt-wiredep',
+5 verbose install     'jit-grunt',
+5 verbose install     'jshint-stylish',
+5 verbose install     'karma',
+5 verbose install     'karma-chrome-launcher',
+5 verbose install     'karma-coffee-preprocessor',
+5 verbose install     'karma-firefox-launcher',
+5 verbose install     'karma-html2js-preprocessor',
+5 verbose install     'karma-jade-preprocessor',
+5 verbose install     'karma-jasmine',
+5 verbose install     'karma-ng-html2js-preprocessor',
+5 verbose install     'karma-ng-jade2js-preprocessor',
+5 verbose install     'karma-ng-scenario',
+5 verbose install     'karma-phantomjs-launcher',
+5 verbose install     'karma-requirejs',
+5 verbose install     'karma-script-launcher',
+5 verbose install     'open',
+5 verbose install     'requirejs',
+5 verbose install     'should',
+5 verbose install     'supertest',
+5 verbose install     'time-grunt' ] ]
+6 verbose install where, peers [ 'C:\\Users\\Owner\\Documents\\GitHub\\FULLSTACK\\backend\\MEAN\\meanbase-1.0.0',
+6 verbose install   [] ]
+7 info preinstall meanbase@0.0.0
+8 silly cache add args [ 'decompress@^2.3.0', null ]
+9 verbose cache add spec decompress@^2.3.0
+10 silly cache add parsed spec { raw: 'decompress@^2.3.0',
+10 silly cache add   scope: null,
+10 silly cache add   name: 'decompress',
+10 silly cache add   rawSpec: '^2.3.0',
+10 silly cache add   spec: '>=2.3.0 <3.0.0',
+10 silly cache add   type: 'range' }
+11 verbose addNamed decompress@>=2.3.0 <3.0.0
+12 silly addNamed semver.valid null
+13 silly addNamed semver.validRange >=2.3.0 <3.0.0
+14 silly addNameRange { name: 'decompress', range: '>=2.3.0 <3.0.0', hasData: false }
+15 silly mapToRegistry name decompress
+16 silly mapToRegistry using default registry
+17 silly mapToRegistry registry https://registry.npmjs.org/
+18 silly mapToRegistry uri https://registry.npmjs.org/decompress
+19 verbose addNameRange registry:https://registry.npmjs.org/decompress not in flight; fetching
+20 silly cache add args [ 'decompress-unzip@^3.2.2', null ]
+21 verbose cache add spec decompress-unzip@^3.2.2
+22 silly cache add parsed spec { raw: 'decompress-unzip@^3.2.2',
+22 silly cache add   scope: null,
+22 silly cache add   name: 'decompress-unzip',
+22 silly cache add   rawSpec: '^3.2.2',
+22 silly cache add   spec: '>=3.2.2 <4.0.0',
+22 silly cache add   type: 'range' }
+23 verbose addNamed decompress-unzip@>=3.2.2 <4.0.0
+24 silly addNamed semver.valid null
+25 silly addNamed semver.validRange >=3.2.2 <4.0.0
+26 silly addNameRange { name: 'decompress-unzip',
+26 silly addNameRange   range: '>=3.2.2 <4.0.0',
+26 silly addNameRange   hasData: false }
+27 silly mapToRegistry name decompress-unzip
+28 silly mapToRegistry using default registry
+29 silly mapToRegistry registry https://registry.npmjs.org/
+30 silly mapToRegistry uri https://registry.npmjs.org/decompress-unzip
+31 verbose addNameRange registry:https://registry.npmjs.org/decompress-unzip not in flight; fetching
+32 silly cache add args [ 'errorhandler@~1.0.0', null ]
+33 verbose cache add spec errorhandler@~1.0.0
+34 silly cache add parsed spec { raw: 'errorhandler@~1.0.0',
+34 silly cache add   scope: null,
+34 silly cache add   name: 'errorhandler',
+34 silly cache add   rawSpec: '~1.0.0',
+34 silly cache add   spec: '>=1.0.0 <1.1.0',
+34 silly cache add   type: 'range' }
+35 verbose addNamed errorhandler@>=1.0.0 <1.1.0
+36 silly addNamed semver.valid null
+37 silly addNamed semver.validRange >=1.0.0 <1.1.0
+38 silly addNameRange { name: 'errorhandler', range: '>=1.0.0 <1.1.0', hasData: false }
+39 silly mapToRegistry name errorhandler
+40 silly mapToRegistry using default registry
+41 silly mapToRegistry registry https://registry.npmjs.org/
+42 silly mapToRegistry uri https://registry.npmjs.org/errorhandler
+43 verbose addNameRange registry:https://registry.npmjs.org/errorhandler not in flight; fetching
+44 silly cache add args [ 'express@~4.0.0', null ]
+45 verbose cache add spec express@~4.0.0
+46 silly cache add parsed spec { raw: 'express@~4.0.0',
+46 silly cache add   scope: null,
+46 silly cache add   name: 'express',
+46 silly cache add   rawSpec: '~4.0.0',
+46 silly cache add   spec: '>=4.0.0 <4.1.0',
+46 silly cache add   type: 'range' }
+47 verbose addNamed express@>=4.0.0 <4.1.0
+48 silly addNamed semver.valid null
+49 silly addNamed semver.validRange >=4.0.0 <4.1.0
+50 silly addNameRange { name: 'express', range: '>=4.0.0 <4.1.0', hasData: false }
+51 silly mapToRegistry name express
+52 silly mapToRegistry using default registry
+53 silly mapToRegistry registry https://registry.npmjs.org/
+54 silly mapToRegistry uri https://registry.npmjs.org/express
+55 verbose addNameRange registry:https://registry.npmjs.org/express not in flight; fetching
+56 silly cache add args [ 'express-jwt@^0.1.3', null ]
+57 verbose cache add spec express-jwt@^0.1.3
+58 silly cache add parsed spec { raw: 'express-jwt@^0.1.3',
+58 silly cache add   scope: null,
+58 silly cache add   name: 'express-jwt',
+58 silly cache add   rawSpec: '^0.1.3',
+58 silly cache add   spec: '>=0.1.3 <0.2.0',
+58 silly cache add   type: 'range' }
+59 verbose addNamed express-jwt@>=0.1.3 <0.2.0
+60 silly addNamed semver.valid null
+61 silly addNamed semver.validRange >=0.1.3 <0.2.0
+62 silly addNameRange { name: 'express-jwt', range: '>=0.1.3 <0.2.0', hasData: false }
+63 silly mapToRegistry name express-jwt
+64 silly mapToRegistry using default registry
+65 silly mapToRegistry registry https://registry.npmjs.org/
+66 silly mapToRegistry uri https://registry.npmjs.org/express-jwt
+67 verbose addNameRange registry:https://registry.npmjs.org/express-jwt not in flight; fetching
+68 silly cache add args [ 'express-session@~1.0.2', null ]
+69 verbose cache add spec express-session@~1.0.2
+70 silly cache add parsed spec { raw: 'express-session@~1.0.2',
+70 silly cache add   scope: null,
+70 silly cache add   name: 'express-session',
+70 silly cache add   rawSpec: '~1.0.2',
+70 silly cache add   spec: '>=1.0.2 <1.1.0',
+70 silly cache add   type: 'range' }
+71 verbose addNamed express-session@>=1.0.2 <1.1.0
+72 silly addNamed semver.valid null
+73 silly addNamed semver.validRange >=1.0.2 <1.1.0
+74 silly addNameRange { name: 'express-session',
+74 silly addNameRange   range: '>=1.0.2 <1.1.0',
+74 silly addNameRange   hasData: false }
+75 silly mapToRegistry name express-session
+76 silly mapToRegistry using default registry
+77 silly mapToRegistry registry https://registry.npmjs.org/
+78 silly mapToRegistry uri https://registry.npmjs.org/express-session
+79 verbose addNameRange registry:https://registry.npmjs.org/express-session not in flight; fetching
+80 silly cache add args [ 'formidable@^1.0.17', null ]
+81 verbose cache add spec formidable@^1.0.17
+82 silly cache add parsed spec { raw: 'formidable@^1.0.17',
+82 silly cache add   scope: null,
+82 silly cache add   name: 'formidable',
+82 silly cache add   rawSpec: '^1.0.17',
+82 silly cache add   spec: '>=1.0.17 <2.0.0',
+82 silly cache add   type: 'range' }
+83 verbose addNamed formidable@>=1.0.17 <2.0.0
+84 silly addNamed semver.valid null
+85 silly addNamed semver.validRange >=1.0.17 <2.0.0
+86 silly addNameRange { name: 'formidable', range: '>=1.0.17 <2.0.0', hasData: false }
+87 silly mapToRegistry name formidable
+88 silly mapToRegistry using default registry
+89 silly mapToRegistry registry https://registry.npmjs.org/
+90 silly mapToRegistry uri https://registry.npmjs.org/formidable
+91 verbose addNameRange registry:https://registry.npmjs.org/formidable not in flight; fetching
+92 silly cache add args [ 'fs-extra@^0.18.2', null ]
+93 verbose cache add spec fs-extra@^0.18.2
+94 silly cache add parsed spec { raw: 'fs-extra@^0.18.2',
+94 silly cache add   scope: null,
+94 silly cache add   name: 'fs-extra',
+94 silly cache add   rawSpec: '^0.18.2',
+94 silly cache add   spec: '>=0.18.2 <0.19.0',
+94 silly cache add   type: 'range' }
+95 verbose addNamed fs-extra@>=0.18.2 <0.19.0
+96 silly addNamed semver.valid null
+97 silly addNamed semver.validRange >=0.18.2 <0.19.0
+98 silly addNameRange { name: 'fs-extra', range: '>=0.18.2 <0.19.0', hasData: false }
+99 silly mapToRegistry name fs-extra
+100 silly mapToRegistry using default registry
+101 silly mapToRegistry registry https://registry.npmjs.org/
+102 silly mapToRegistry uri https://registry.npmjs.org/fs-extra
+103 verbose addNameRange registry:https://registry.npmjs.org/fs-extra not in flight; fetching
+104 silly cache add args [ 'fs-finder@^1.8.0', null ]
+105 verbose cache add spec fs-finder@^1.8.0
+106 silly cache add parsed spec { raw: 'fs-finder@^1.8.0',
+106 silly cache add   scope: null,
+106 silly cache add   name: 'fs-finder',
+106 silly cache add   rawSpec: '^1.8.0',
+106 silly cache add   spec: '>=1.8.0 <2.0.0',
+106 silly cache add   type: 'range' }
+107 verbose addNamed fs-finder@>=1.8.0 <2.0.0
+108 silly addNamed semver.valid null
+109 silly addNamed semver.validRange >=1.8.0 <2.0.0
+110 silly addNameRange { name: 'fs-finder', range: '>=1.8.0 <2.0.0', hasData: false }
+111 silly mapToRegistry name fs-finder
+112 silly mapToRegistry using default registry
+113 silly mapToRegistry registry https://registry.npmjs.org/
+114 silly mapToRegistry uri https://registry.npmjs.org/fs-finder
+115 verbose addNameRange registry:https://registry.npmjs.org/fs-finder not in flight; fetching
+116 silly cache add args [ 'gm@^1.18.1', null ]
+117 verbose cache add spec gm@^1.18.1
+118 silly cache add parsed spec { raw: 'gm@^1.18.1',
+118 silly cache add   scope: null,
+118 silly cache add   name: 'gm',
+118 silly cache add   rawSpec: '^1.18.1',
+118 silly cache add   spec: '>=1.18.1 <2.0.0',
+118 silly cache add   type: 'range' }
+119 verbose addNamed gm@>=1.18.1 <2.0.0
+120 silly addNamed semver.valid null
+121 silly addNamed semver.validRange >=1.18.1 <2.0.0
+122 silly addNameRange { name: 'gm', range: '>=1.18.1 <2.0.0', hasData: false }
+123 silly mapToRegistry name gm
+124 silly mapToRegistry using default registry
+125 silly mapToRegistry registry https://registry.npmjs.org/
+126 silly mapToRegistry uri https://registry.npmjs.org/gm
+127 verbose addNameRange registry:https://registry.npmjs.org/gm not in flight; fetching
+128 silly cache add args [ 'jade@~1.2.0', null ]
+129 verbose cache add spec jade@~1.2.0
+130 silly cache add parsed spec { raw: 'jade@~1.2.0',
+130 silly cache add   scope: null,
+130 silly cache add   name: 'jade',
+130 silly cache add   rawSpec: '~1.2.0',
+130 silly cache add   spec: '>=1.2.0 <1.3.0',
+130 silly cache add   type: 'range' }
+131 verbose addNamed jade@>=1.2.0 <1.3.0
+132 silly addNamed semver.valid null
+133 silly addNamed semver.validRange >=1.2.0 <1.3.0
+134 silly addNameRange { name: 'jade', range: '>=1.2.0 <1.3.0', hasData: false }
+135 silly mapToRegistry name jade
+136 silly mapToRegistry using default registry
+137 silly mapToRegistry registry https://registry.npmjs.org/
+138 silly mapToRegistry uri https://registry.npmjs.org/jade
+139 verbose addNameRange registry:https://registry.npmjs.org/jade not in flight; fetching
+140 silly cache add args [ 'jade-browser-middleware@^0.3.3', null ]
+141 verbose cache add spec jade-browser-middleware@^0.3.3
+142 silly cache add parsed spec { raw: 'jade-browser-middleware@^0.3.3',
+142 silly cache add   scope: null,
+142 silly cache add   name: 'jade-browser-middleware',
+142 silly cache add   rawSpec: '^0.3.3',
+142 silly cache add   spec: '>=0.3.3 <0.4.0',
+142 silly cache add   type: 'range' }
+143 verbose addNamed jade-browser-middleware@>=0.3.3 <0.4.0
+144 silly addNamed semver.valid null
+145 silly addNamed semver.validRange >=0.3.3 <0.4.0
+146 silly addNameRange { name: 'jade-browser-middleware',
+146 silly addNameRange   range: '>=0.3.3 <0.4.0',
+146 silly addNameRange   hasData: false }
+147 silly mapToRegistry name jade-browser-middleware
+148 silly mapToRegistry using default registry
+149 silly mapToRegistry registry https://registry.npmjs.org/
+150 silly mapToRegistry uri https://registry.npmjs.org/jade-browser-middleware
+151 verbose addNameRange registry:https://registry.npmjs.org/jade-browser-middleware not in flight; fetching
+152 silly cache add args [ 'jsonwebtoken@^0.3.0', null ]
+153 verbose cache add spec jsonwebtoken@^0.3.0
+154 silly cache add parsed spec { raw: 'jsonwebtoken@^0.3.0',
+154 silly cache add   scope: null,
+154 silly cache add   name: 'jsonwebtoken',
+154 silly cache add   rawSpec: '^0.3.0',
+154 silly cache add   spec: '>=0.3.0 <0.4.0',
+154 silly cache add   type: 'range' }
+155 verbose addNamed jsonwebtoken@>=0.3.0 <0.4.0
+156 silly addNamed semver.valid null
+157 silly addNamed semver.validRange >=0.3.0 <0.4.0
+158 silly addNameRange { name: 'jsonwebtoken', range: '>=0.3.0 <0.4.0', hasData: false }
+159 silly mapToRegistry name jsonwebtoken
+160 silly mapToRegistry using default registry
+161 silly mapToRegistry registry https://registry.npmjs.org/
+162 silly mapToRegistry uri https://registry.npmjs.org/jsonwebtoken
+163 verbose addNameRange registry:https://registry.npmjs.org/jsonwebtoken not in flight; fetching
+164 silly cache add args [ 'lodash@~2.4.1', null ]
+165 verbose cache add spec lodash@~2.4.1
+166 silly cache add parsed spec { raw: 'lodash@~2.4.1',
+166 silly cache add   scope: null,
+166 silly cache add   name: 'lodash',
+166 silly cache add   rawSpec: '~2.4.1',
+166 silly cache add   spec: '>=2.4.1 <2.5.0',
+166 silly cache add   type: 'range' }
+167 verbose addNamed lodash@>=2.4.1 <2.5.0
+168 silly addNamed semver.valid null
+169 silly addNamed semver.validRange >=2.4.1 <2.5.0
+170 silly addNameRange { name: 'lodash', range: '>=2.4.1 <2.5.0', hasData: false }
+171 silly mapToRegistry name lodash
+172 silly mapToRegistry using default registry
+173 silly mapToRegistry registry https://registry.npmjs.org/
+174 silly mapToRegistry uri https://registry.npmjs.org/lodash
+175 verbose addNameRange registry:https://registry.npmjs.org/lodash not in flight; fetching
+176 silly cache add args [ 'method-override@~1.0.0', null ]
+177 verbose cache add spec method-override@~1.0.0
+178 silly cache add parsed spec { raw: 'method-override@~1.0.0',
+178 silly cache add   scope: null,
+178 silly cache add   name: 'method-override',
+178 silly cache add   rawSpec: '~1.0.0',
+178 silly cache add   spec: '>=1.0.0 <1.1.0',
+178 silly cache add   type: 'range' }
+179 verbose addNamed method-override@>=1.0.0 <1.1.0
+180 silly addNamed semver.valid null
+181 silly addNamed semver.validRange >=1.0.0 <1.1.0
+182 silly addNameRange { name: 'method-override',
+182 silly addNameRange   range: '>=1.0.0 <1.1.0',
+182 silly addNameRange   hasData: false }
+183 silly mapToRegistry name method-override
+184 silly mapToRegistry using default registry
+185 silly mapToRegistry registry https://registry.npmjs.org/
+186 silly mapToRegistry uri https://registry.npmjs.org/method-override
+187 verbose addNameRange registry:https://registry.npmjs.org/method-override not in flight; fetching
+188 silly cache add args [ 'mongoose@~3.8.8', null ]
+189 verbose cache add spec mongoose@~3.8.8
+190 silly cache add parsed spec { raw: 'mongoose@~3.8.8',
+190 silly cache add   scope: null,
+190 silly cache add   name: 'mongoose',
+190 silly cache add   rawSpec: '~3.8.8',
+190 silly cache add   spec: '>=3.8.8 <3.9.0',
+190 silly cache add   type: 'range' }
+191 verbose addNamed mongoose@>=3.8.8 <3.9.0
+192 silly addNamed semver.valid null
+193 silly addNamed semver.validRange >=3.8.8 <3.9.0
+194 silly addNameRange { name: 'mongoose', range: '>=3.8.8 <3.9.0', hasData: false }
+195 silly mapToRegistry name mongoose
+196 silly mapToRegistry using default registry
+197 silly mapToRegistry registry https://registry.npmjs.org/
+198 silly mapToRegistry uri https://registry.npmjs.org/mongoose
+199 verbose addNameRange registry:https://registry.npmjs.org/mongoose not in flight; fetching
+200 silly cache add args [ 'mongoose-text-search@0.0.2', null ]
+201 verbose cache add spec mongoose-text-search@0.0.2
+202 silly cache add parsed spec { raw: 'mongoose-text-search@0.0.2',
+202 silly cache add   scope: null,
+202 silly cache add   name: 'mongoose-text-search',
+202 silly cache add   rawSpec: '0.0.2',
+202 silly cache add   spec: '0.0.2',
+202 silly cache add   type: 'version' }
+203 verbose addNamed mongoose-text-search@0.0.2
+204 silly addNamed semver.valid 0.0.2
+205 silly addNamed semver.validRange 0.0.2
+206 silly mapToRegistry name mongoose-text-search
+207 silly mapToRegistry using default registry
+208 silly mapToRegistry registry https://registry.npmjs.org/
+209 silly mapToRegistry uri https://registry.npmjs.org/mongoose-text-search
+210 verbose addNameVersion registry:https://registry.npmjs.org/mongoose-text-search not in flight; fetching
+211 silly cache add args [ 'mongoose-validators@^0.1.0', null ]
+212 verbose cache add spec mongoose-validators@^0.1.0
+213 silly cache add parsed spec { raw: 'mongoose-validators@^0.1.0',
+213 silly cache add   scope: null,
+213 silly cache add   name: 'mongoose-validators',
+213 silly cache add   rawSpec: '^0.1.0',
+213 silly cache add   spec: '>=0.1.0 <0.2.0',
+213 silly cache add   type: 'range' }
+214 verbose addNamed mongoose-validators@>=0.1.0 <0.2.0
+215 silly addNamed semver.valid null
+216 silly addNamed semver.validRange >=0.1.0 <0.2.0
+217 silly addNameRange { name: 'mongoose-validators',
+217 silly addNameRange   range: '>=0.1.0 <0.2.0',
+217 silly addNameRange   hasData: false }
+218 silly mapToRegistry name mongoose-validators
+219 silly mapToRegistry using default registry
+220 silly mapToRegistry registry https://registry.npmjs.org/
+221 silly mapToRegistry uri https://registry.npmjs.org/mongoose-validators
+222 verbose addNameRange registry:https://registry.npmjs.org/mongoose-validators not in flight; fetching
+223 silly cache add args [ 'morgan@~1.0.0', null ]
+224 verbose cache add spec morgan@~1.0.0
+225 silly cache add parsed spec { raw: 'morgan@~1.0.0',
+225 silly cache add   scope: null,
+225 silly cache add   name: 'morgan',
+225 silly cache add   rawSpec: '~1.0.0',
+225 silly cache add   spec: '>=1.0.0 <1.1.0',
+225 silly cache add   type: 'range' }
+226 verbose addNamed morgan@>=1.0.0 <1.1.0
+227 silly addNamed semver.valid null
+228 silly addNamed semver.validRange >=1.0.0 <1.1.0
+229 silly addNameRange { name: 'morgan', range: '>=1.0.0 <1.1.0', hasData: false }
+230 silly mapToRegistry name morgan
+231 silly mapToRegistry using default registry
+232 silly mapToRegistry registry https://registry.npmjs.org/
+233 silly mapToRegistry uri https://registry.npmjs.org/morgan
+234 verbose addNameRange registry:https://registry.npmjs.org/morgan not in flight; fetching
+235 silly cache add args [ 'multer@^0.1.8', null ]
+236 verbose cache add spec multer@^0.1.8
+237 silly cache add parsed spec { raw: 'multer@^0.1.8',
+237 silly cache add   scope: null,
+237 silly cache add   name: 'multer',
+237 silly cache add   rawSpec: '^0.1.8',
+237 silly cache add   spec: '>=0.1.8 <0.2.0',
+237 silly cache add   type: 'range' }
+238 verbose addNamed multer@>=0.1.8 <0.2.0
+239 silly addNamed semver.valid null
+240 silly addNamed semver.validRange >=0.1.8 <0.2.0
+241 silly addNameRange { name: 'multer', range: '>=0.1.8 <0.2.0', hasData: false }
+242 silly mapToRegistry name multer
+243 silly mapToRegistry using default registry
+244 silly mapToRegistry registry https://registry.npmjs.org/
+245 silly mapToRegistry uri https://registry.npmjs.org/multer
+246 verbose addNameRange registry:https://registry.npmjs.org/multer not in flight; fetching
+247 silly cache add args [ 'passport@~0.2.0', null ]
+248 verbose cache add spec passport@~0.2.0
+249 silly cache add parsed spec { raw: 'passport@~0.2.0',
+249 silly cache add   scope: null,
+249 silly cache add   name: 'passport',
+249 silly cache add   rawSpec: '~0.2.0',
+249 silly cache add   spec: '>=0.2.0 <0.3.0',
+249 silly cache add   type: 'range' }
+250 verbose addNamed passport@>=0.2.0 <0.3.0
+251 silly addNamed semver.valid null
+252 silly addNamed semver.validRange >=0.2.0 <0.3.0
+253 silly addNameRange { name: 'passport', range: '>=0.2.0 <0.3.0', hasData: false }
+254 silly mapToRegistry name passport
+255 silly mapToRegistry using default registry
+256 silly mapToRegistry registry https://registry.npmjs.org/
+257 silly mapToRegistry uri https://registry.npmjs.org/passport
+258 verbose addNameRange registry:https://registry.npmjs.org/passport not in flight; fetching
+259 silly cache add args [ 'passport-facebook@latest', null ]
+260 verbose cache add spec passport-facebook@latest
+261 silly cache add args [ 'passport-google-oauth@latest', null ]
+262 verbose cache add spec passport-google-oauth@latest
+263 silly cache add args [ 'passport-local@~0.1.6', null ]
+264 verbose cache add spec passport-local@~0.1.6
+265 silly cache add parsed spec { raw: 'passport-local@~0.1.6',
+265 silly cache add   scope: null,
+265 silly cache add   name: 'passport-local',
+265 silly cache add   rawSpec: '~0.1.6',
+265 silly cache add   spec: '>=0.1.6 <0.2.0',
+265 silly cache add   type: 'range' }
+266 verbose addNamed passport-local@>=0.1.6 <0.2.0
+267 silly addNamed semver.valid null
+268 silly addNamed semver.validRange >=0.1.6 <0.2.0
+269 silly addNameRange { name: 'passport-local',
+269 silly addNameRange   range: '>=0.1.6 <0.2.0',
+269 silly addNameRange   hasData: false }
+270 silly mapToRegistry name passport-local
+271 silly mapToRegistry using default registry
+272 silly mapToRegistry registry https://registry.npmjs.org/
+273 silly mapToRegistry uri https://registry.npmjs.org/passport-local
+274 verbose addNameRange registry:https://registry.npmjs.org/passport-local not in flight; fetching
+275 silly cache add args [ 'passport-twitter@latest', null ]
+276 verbose cache add spec passport-twitter@latest
+277 silly cache add args [ 'prerender-node@^1.2.1', null ]
+278 verbose cache add spec prerender-node@^1.2.1
+279 silly cache add parsed spec { raw: 'prerender-node@^1.2.1',
+279 silly cache add   scope: null,
+279 silly cache add   name: 'prerender-node',
+279 silly cache add   rawSpec: '^1.2.1',
+279 silly cache add   spec: '>=1.2.1 <2.0.0',
+279 silly cache add   type: 'range' }
+280 verbose addNamed prerender-node@>=1.2.1 <2.0.0
+281 silly addNamed semver.valid null
+282 silly addNamed semver.validRange >=1.2.1 <2.0.0
+283 silly addNameRange { name: 'prerender-node',
+283 silly addNameRange   range: '>=1.2.1 <2.0.0',
+283 silly addNameRange   hasData: false }
+284 silly mapToRegistry name prerender-node
+285 silly mapToRegistry using default registry
+286 silly mapToRegistry registry https://registry.npmjs.org/
+287 silly mapToRegistry uri https://registry.npmjs.org/prerender-node
+288 verbose addNameRange registry:https://registry.npmjs.org/prerender-node not in flight; fetching
+289 silly cache add args [ 'promise@^7.0.1', null ]
+290 verbose cache add spec promise@^7.0.1
+291 silly cache add parsed spec { raw: 'promise@^7.0.1',
+291 silly cache add   scope: null,
+291 silly cache add   name: 'promise',
+291 silly cache add   rawSpec: '^7.0.1',
+291 silly cache add   spec: '>=7.0.1 <8.0.0',
+291 silly cache add   type: 'range' }
+292 verbose addNamed promise@>=7.0.1 <8.0.0
+293 silly addNamed semver.valid null
+294 silly addNamed semver.validRange >=7.0.1 <8.0.0
+295 silly addNameRange { name: 'promise', range: '>=7.0.1 <8.0.0', hasData: false }
+296 silly mapToRegistry name promise
+297 silly mapToRegistry using default registry
+298 silly mapToRegistry registry https://registry.npmjs.org/
+299 silly mapToRegistry uri https://registry.npmjs.org/promise
+300 verbose addNameRange registry:https://registry.npmjs.org/promise not in flight; fetching
+301 silly cache add args [ 'serve-favicon@~2.0.1', null ]
+302 verbose cache add spec serve-favicon@~2.0.1
+303 silly cache add parsed spec { raw: 'serve-favicon@~2.0.1',
+303 silly cache add   scope: null,
+303 silly cache add   name: 'serve-favicon',
+303 silly cache add   rawSpec: '~2.0.1',
+303 silly cache add   spec: '>=2.0.1 <2.1.0',
+303 silly cache add   type: 'range' }
+304 verbose addNamed serve-favicon@>=2.0.1 <2.1.0
+305 silly addNamed semver.valid null
+306 silly addNamed semver.validRange >=2.0.1 <2.1.0
+307 silly addNameRange { name: 'serve-favicon',
+307 silly addNameRange   range: '>=2.0.1 <2.1.0',
+307 silly addNameRange   hasData: false }
+308 silly mapToRegistry name serve-favicon
+309 silly mapToRegistry using default registry
+310 silly mapToRegistry registry https://registry.npmjs.org/
+311 silly mapToRegistry uri https://registry.npmjs.org/serve-favicon
+312 verbose addNameRange registry:https://registry.npmjs.org/serve-favicon not in flight; fetching
+313 silly cache add args [ 'winston@^1.0.0', null ]
+314 verbose cache add spec winston@^1.0.0
+315 silly cache add parsed spec { raw: 'winston@^1.0.0',
+315 silly cache add   scope: null,
+315 silly cache add   name: 'winston',
+315 silly cache add   rawSpec: '^1.0.0',
+315 silly cache add   spec: '>=1.0.0 <2.0.0',
+315 silly cache add   type: 'range' }
+316 verbose addNamed winston@>=1.0.0 <2.0.0
+317 silly addNamed semver.valid null
+318 silly addNamed semver.validRange >=1.0.0 <2.0.0
+319 silly addNameRange { name: 'winston', range: '>=1.0.0 <2.0.0', hasData: false }
+320 silly mapToRegistry name winston
+321 silly mapToRegistry using default registry
+322 silly mapToRegistry registry https://registry.npmjs.org/
+323 silly mapToRegistry uri https://registry.npmjs.org/winston
+324 verbose addNameRange registry:https://registry.npmjs.org/winston not in flight; fetching
+325 silly cache add args [ 'xml-to-json@^0.1.1', null ]
+326 verbose cache add spec xml-to-json@^0.1.1
+327 silly cache add parsed spec { raw: 'xml-to-json@^0.1.1',
+327 silly cache add   scope: null,
+327 silly cache add   name: 'xml-to-json',
+327 silly cache add   rawSpec: '^0.1.1',
+327 silly cache add   spec: '>=0.1.1 <0.2.0',
+327 silly cache add   type: 'range' }
+328 verbose addNamed xml-to-json@>=0.1.1 <0.2.0
+329 silly addNamed semver.valid null
+330 silly addNamed semver.validRange >=0.1.1 <0.2.0
+331 silly addNameRange { name: 'xml-to-json', range: '>=0.1.1 <0.2.0', hasData: false }
+332 silly mapToRegistry name xml-to-json
+333 silly mapToRegistry using default registry
+334 silly mapToRegistry registry https://registry.npmjs.org/
+335 silly mapToRegistry uri https://registry.npmjs.org/xml-to-json
+336 verbose addNameRange registry:https://registry.npmjs.org/xml-to-json not in flight; fetching
+337 silly cache add args [ 'connect-livereload@~0.4.0', null ]
+338 verbose cache add spec connect-livereload@~0.4.0
+339 silly cache add parsed spec { raw: 'connect-livereload@~0.4.0',
+339 silly cache add   scope: null,
+339 silly cache add   name: 'connect-livereload',
+339 silly cache add   rawSpec: '~0.4.0',
+339 silly cache add   spec: '>=0.4.0 <0.5.0',
+339 silly cache add   type: 'range' }
+340 verbose addNamed connect-livereload@>=0.4.0 <0.5.0
+341 silly addNamed semver.valid null
+342 silly addNamed semver.validRange >=0.4.0 <0.5.0
+343 silly addNameRange { name: 'connect-livereload',
+343 silly addNameRange   range: '>=0.4.0 <0.5.0',
+343 silly addNameRange   hasData: false }
+344 silly mapToRegistry name connect-livereload
+345 silly mapToRegistry using default registry
+346 silly mapToRegistry registry https://registry.npmjs.org/
+347 silly mapToRegistry uri https://registry.npmjs.org/connect-livereload
+348 verbose addNameRange registry:https://registry.npmjs.org/connect-livereload not in flight; fetching
+349 silly cache add args [ 'grunt@~0.4.4', null ]
+350 verbose cache add spec grunt@~0.4.4
+351 silly cache add parsed spec { raw: 'grunt@~0.4.4',
+351 silly cache add   scope: null,
+351 silly cache add   name: 'grunt',
+351 silly cache add   rawSpec: '~0.4.4',
+351 silly cache add   spec: '>=0.4.4 <0.5.0',
+351 silly cache add   type: 'range' }
+352 verbose addNamed grunt@>=0.4.4 <0.5.0
+353 silly addNamed semver.valid null
+354 silly addNamed semver.validRange >=0.4.4 <0.5.0
+355 silly addNameRange { name: 'grunt', range: '>=0.4.4 <0.5.0', hasData: false }
+356 silly mapToRegistry name grunt
+357 silly mapToRegistry using default registry
+358 silly mapToRegistry registry https://registry.npmjs.org/
+359 silly mapToRegistry uri https://registry.npmjs.org/grunt
+360 verbose addNameRange registry:https://registry.npmjs.org/grunt not in flight; fetching
+361 silly cache add args [ 'grunt-angular-templates@^0.5.4', null ]
+362 verbose cache add spec grunt-angular-templates@^0.5.4
+363 silly cache add parsed spec { raw: 'grunt-angular-templates@^0.5.4',
+363 silly cache add   scope: null,
+363 silly cache add   name: 'grunt-angular-templates',
+363 silly cache add   rawSpec: '^0.5.4',
+363 silly cache add   spec: '>=0.5.4 <0.6.0',
+363 silly cache add   type: 'range' }
+364 verbose addNamed grunt-angular-templates@>=0.5.4 <0.6.0
+365 silly addNamed semver.valid null
+366 silly addNamed semver.validRange >=0.5.4 <0.6.0
+367 silly addNameRange { name: 'grunt-angular-templates',
+367 silly addNameRange   range: '>=0.5.4 <0.6.0',
+367 silly addNameRange   hasData: false }
+368 silly mapToRegistry name grunt-angular-templates
+369 silly mapToRegistry using default registry
+370 silly mapToRegistry registry https://registry.npmjs.org/
+371 silly mapToRegistry uri https://registry.npmjs.org/grunt-angular-templates
+372 verbose addNameRange registry:https://registry.npmjs.org/grunt-angular-templates not in flight; fetching
+373 silly cache add args [ 'grunt-asset-injector@^0.1.0', null ]
+374 verbose cache add spec grunt-asset-injector@^0.1.0
+375 silly cache add parsed spec { raw: 'grunt-asset-injector@^0.1.0',
+375 silly cache add   scope: null,
+375 silly cache add   name: 'grunt-asset-injector',
+375 silly cache add   rawSpec: '^0.1.0',
+375 silly cache add   spec: '>=0.1.0 <0.2.0',
+375 silly cache add   type: 'range' }
+376 verbose addNamed grunt-asset-injector@>=0.1.0 <0.2.0
+377 silly addNamed semver.valid null
+378 silly addNamed semver.validRange >=0.1.0 <0.2.0
+379 silly addNameRange { name: 'grunt-asset-injector',
+379 silly addNameRange   range: '>=0.1.0 <0.2.0',
+379 silly addNameRange   hasData: false }
+380 silly mapToRegistry name grunt-asset-injector
+381 silly mapToRegistry using default registry
+382 silly mapToRegistry registry https://registry.npmjs.org/
+383 silly mapToRegistry uri https://registry.npmjs.org/grunt-asset-injector
+384 verbose addNameRange registry:https://registry.npmjs.org/grunt-asset-injector not in flight; fetching
+385 silly cache add args [ 'grunt-autoprefixer@~0.7.2', null ]
+386 verbose cache add spec grunt-autoprefixer@~0.7.2
+387 silly cache add parsed spec { raw: 'grunt-autoprefixer@~0.7.2',
+387 silly cache add   scope: null,
+387 silly cache add   name: 'grunt-autoprefixer',
+387 silly cache add   rawSpec: '~0.7.2',
+387 silly cache add   spec: '>=0.7.2 <0.8.0',
+387 silly cache add   type: 'range' }
+388 verbose addNamed grunt-autoprefixer@>=0.7.2 <0.8.0
+389 silly addNamed semver.valid null
+390 silly addNamed semver.validRange >=0.7.2 <0.8.0
+391 silly addNameRange { name: 'grunt-autoprefixer',
+391 silly addNameRange   range: '>=0.7.2 <0.8.0',
+391 silly addNameRange   hasData: false }
+392 silly mapToRegistry name grunt-autoprefixer
+393 silly mapToRegistry using default registry
+394 silly mapToRegistry registry https://registry.npmjs.org/
+395 silly mapToRegistry uri https://registry.npmjs.org/grunt-autoprefixer
+396 verbose addNameRange registry:https://registry.npmjs.org/grunt-autoprefixer not in flight; fetching
+397 silly cache add args [ 'grunt-build-control@git+https://github.com/DaftMonk/grunt-build-control',
+397 silly cache add   null ]
+398 verbose cache add spec grunt-build-control@git+https://github.com/DaftMonk/grunt-build-control
+399 silly cache add args [ 'grunt-concurrent@~0.5.0', null ]
+400 verbose cache add spec grunt-concurrent@~0.5.0
+401 silly cache add parsed spec { raw: 'grunt-concurrent@~0.5.0',
+401 silly cache add   scope: null,
+401 silly cache add   name: 'grunt-concurrent',
+401 silly cache add   rawSpec: '~0.5.0',
+401 silly cache add   spec: '>=0.5.0 <0.6.0',
+401 silly cache add   type: 'range' }
+402 verbose addNamed grunt-concurrent@>=0.5.0 <0.6.0
+403 silly addNamed semver.valid null
+404 silly addNamed semver.validRange >=0.5.0 <0.6.0
+405 silly addNameRange { name: 'grunt-concurrent',
+405 silly addNameRange   range: '>=0.5.0 <0.6.0',
+405 silly addNameRange   hasData: false }
+406 silly mapToRegistry name grunt-concurrent
+407 silly mapToRegistry using default registry
+408 silly mapToRegistry registry https://registry.npmjs.org/
+409 silly mapToRegistry uri https://registry.npmjs.org/grunt-concurrent
+410 verbose addNameRange registry:https://registry.npmjs.org/grunt-concurrent not in flight; fetching
+411 silly cache add args [ 'grunt-contrib-clean@~0.5.0', null ]
+412 verbose cache add spec grunt-contrib-clean@~0.5.0
+413 silly cache add parsed spec { raw: 'grunt-contrib-clean@~0.5.0',
+413 silly cache add   scope: null,
+413 silly cache add   name: 'grunt-contrib-clean',
+413 silly cache add   rawSpec: '~0.5.0',
+413 silly cache add   spec: '>=0.5.0 <0.6.0',
+413 silly cache add   type: 'range' }
+414 verbose addNamed grunt-contrib-clean@>=0.5.0 <0.6.0
+415 silly addNamed semver.valid null
+416 silly addNamed semver.validRange >=0.5.0 <0.6.0
+417 silly addNameRange { name: 'grunt-contrib-clean',
+417 silly addNameRange   range: '>=0.5.0 <0.6.0',
+417 silly addNameRange   hasData: false }
+418 silly mapToRegistry name grunt-contrib-clean
+419 silly mapToRegistry using default registry
+420 silly mapToRegistry registry https://registry.npmjs.org/
+421 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-clean
+422 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-clean not in flight; fetching
+423 silly cache add args [ 'grunt-contrib-copy@~0.5.0', null ]
+424 verbose cache add spec grunt-contrib-copy@~0.5.0
+425 silly cache add parsed spec { raw: 'grunt-contrib-copy@~0.5.0',
+425 silly cache add   scope: null,
+425 silly cache add   name: 'grunt-contrib-copy',
+425 silly cache add   rawSpec: '~0.5.0',
+425 silly cache add   spec: '>=0.5.0 <0.6.0',
+425 silly cache add   type: 'range' }
+426 verbose addNamed grunt-contrib-copy@>=0.5.0 <0.6.0
+427 silly addNamed semver.valid null
+428 silly addNamed semver.validRange >=0.5.0 <0.6.0
+429 silly addNameRange { name: 'grunt-contrib-copy',
+429 silly addNameRange   range: '>=0.5.0 <0.6.0',
+429 silly addNameRange   hasData: false }
+430 silly mapToRegistry name grunt-contrib-copy
+431 silly mapToRegistry using default registry
+432 silly mapToRegistry registry https://registry.npmjs.org/
+433 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-copy
+434 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-copy not in flight; fetching
+435 silly cache add args [ 'grunt-contrib-cssmin@~0.9.0', null ]
+436 verbose cache add spec grunt-contrib-cssmin@~0.9.0
+437 silly cache add parsed spec { raw: 'grunt-contrib-cssmin@~0.9.0',
+437 silly cache add   scope: null,
+437 silly cache add   name: 'grunt-contrib-cssmin',
+437 silly cache add   rawSpec: '~0.9.0',
+437 silly cache add   spec: '>=0.9.0 <0.10.0',
+437 silly cache add   type: 'range' }
+438 verbose addNamed grunt-contrib-cssmin@>=0.9.0 <0.10.0
+439 silly addNamed semver.valid null
+440 silly addNamed semver.validRange >=0.9.0 <0.10.0
+441 silly addNameRange { name: 'grunt-contrib-cssmin',
+441 silly addNameRange   range: '>=0.9.0 <0.10.0',
+441 silly addNameRange   hasData: false }
+442 silly mapToRegistry name grunt-contrib-cssmin
+443 silly mapToRegistry using default registry
+444 silly mapToRegistry registry https://registry.npmjs.org/
+445 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-cssmin
+446 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-cssmin not in flight; fetching
+447 silly cache add args [ 'grunt-contrib-htmlmin@~0.2.0', null ]
+448 verbose cache add spec grunt-contrib-htmlmin@~0.2.0
+449 silly cache add parsed spec { raw: 'grunt-contrib-htmlmin@~0.2.0',
+449 silly cache add   scope: null,
+449 silly cache add   name: 'grunt-contrib-htmlmin',
+449 silly cache add   rawSpec: '~0.2.0',
+449 silly cache add   spec: '>=0.2.0 <0.3.0',
+449 silly cache add   type: 'range' }
+450 verbose addNamed grunt-contrib-htmlmin@>=0.2.0 <0.3.0
+451 silly addNamed semver.valid null
+452 silly addNamed semver.validRange >=0.2.0 <0.3.0
+453 silly addNameRange { name: 'grunt-contrib-htmlmin',
+453 silly addNameRange   range: '>=0.2.0 <0.3.0',
+453 silly addNameRange   hasData: false }
+454 silly mapToRegistry name grunt-contrib-htmlmin
+455 silly mapToRegistry using default registry
+456 silly mapToRegistry registry https://registry.npmjs.org/
+457 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-htmlmin
+458 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-htmlmin not in flight; fetching
+459 silly cache add args [ 'grunt-contrib-imagemin@~0.7.1', null ]
+460 verbose cache add spec grunt-contrib-imagemin@~0.7.1
+461 silly cache add parsed spec { raw: 'grunt-contrib-imagemin@~0.7.1',
+461 silly cache add   scope: null,
+461 silly cache add   name: 'grunt-contrib-imagemin',
+461 silly cache add   rawSpec: '~0.7.1',
+461 silly cache add   spec: '>=0.7.1 <0.8.0',
+461 silly cache add   type: 'range' }
+462 verbose addNamed grunt-contrib-imagemin@>=0.7.1 <0.8.0
+463 silly addNamed semver.valid null
+464 silly addNamed semver.validRange >=0.7.1 <0.8.0
+465 silly addNameRange { name: 'grunt-contrib-imagemin',
+465 silly addNameRange   range: '>=0.7.1 <0.8.0',
+465 silly addNameRange   hasData: false }
+466 silly mapToRegistry name grunt-contrib-imagemin
+467 silly mapToRegistry using default registry
+468 silly mapToRegistry registry https://registry.npmjs.org/
+469 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-imagemin
+470 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-imagemin not in flight; fetching
+471 silly cache add args [ 'grunt-contrib-jade@^0.11.0', null ]
+472 verbose cache add spec grunt-contrib-jade@^0.11.0
+473 silly cache add parsed spec { raw: 'grunt-contrib-jade@^0.11.0',
+473 silly cache add   scope: null,
+473 silly cache add   name: 'grunt-contrib-jade',
+473 silly cache add   rawSpec: '^0.11.0',
+473 silly cache add   spec: '>=0.11.0 <0.12.0',
+473 silly cache add   type: 'range' }
+474 verbose addNamed grunt-contrib-jade@>=0.11.0 <0.12.0
+475 silly addNamed semver.valid null
+476 silly addNamed semver.validRange >=0.11.0 <0.12.0
+477 silly addNameRange { name: 'grunt-contrib-jade',
+477 silly addNameRange   range: '>=0.11.0 <0.12.0',
+477 silly addNameRange   hasData: false }
+478 silly mapToRegistry name grunt-contrib-jade
+479 silly mapToRegistry using default registry
+480 silly mapToRegistry registry https://registry.npmjs.org/
+481 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-jade
+482 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-jade not in flight; fetching
+483 silly cache add args [ 'grunt-contrib-jshint@~0.10.0', null ]
+484 verbose cache add spec grunt-contrib-jshint@~0.10.0
+485 silly cache add parsed spec { raw: 'grunt-contrib-jshint@~0.10.0',
+485 silly cache add   scope: null,
+485 silly cache add   name: 'grunt-contrib-jshint',
+485 silly cache add   rawSpec: '~0.10.0',
+485 silly cache add   spec: '>=0.10.0 <0.11.0',
+485 silly cache add   type: 'range' }
+486 verbose addNamed grunt-contrib-jshint@>=0.10.0 <0.11.0
+487 silly addNamed semver.valid null
+488 silly addNamed semver.validRange >=0.10.0 <0.11.0
+489 silly addNameRange { name: 'grunt-contrib-jshint',
+489 silly addNameRange   range: '>=0.10.0 <0.11.0',
+489 silly addNameRange   hasData: false }
+490 silly mapToRegistry name grunt-contrib-jshint
+491 silly mapToRegistry using default registry
+492 silly mapToRegistry registry https://registry.npmjs.org/
+493 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-jshint
+494 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-jshint not in flight; fetching
+495 silly cache add args [ 'grunt-contrib-stylus@latest', null ]
+496 verbose cache add spec grunt-contrib-stylus@latest
+497 silly cache add args [ 'grunt-contrib-uglify@~0.4.0', null ]
+498 verbose cache add spec grunt-contrib-uglify@~0.4.0
+499 silly cache add parsed spec { raw: 'grunt-contrib-uglify@~0.4.0',
+499 silly cache add   scope: null,
+499 silly cache add   name: 'grunt-contrib-uglify',
+499 silly cache add   rawSpec: '~0.4.0',
+499 silly cache add   spec: '>=0.4.0 <0.5.0',
+499 silly cache add   type: 'range' }
+500 verbose addNamed grunt-contrib-uglify@>=0.4.0 <0.5.0
+501 silly addNamed semver.valid null
+502 silly addNamed semver.validRange >=0.4.0 <0.5.0
+503 silly addNameRange { name: 'grunt-contrib-uglify',
+503 silly addNameRange   range: '>=0.4.0 <0.5.0',
+503 silly addNameRange   hasData: false }
+504 silly mapToRegistry name grunt-contrib-uglify
+505 silly mapToRegistry using default registry
+506 silly mapToRegistry registry https://registry.npmjs.org/
+507 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-uglify
+508 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-uglify not in flight; fetching
+509 silly cache add args [ 'grunt-contrib-watch@~0.6.1', null ]
+510 verbose cache add spec grunt-contrib-watch@~0.6.1
+511 silly cache add parsed spec { raw: 'grunt-contrib-watch@~0.6.1',
+511 silly cache add   scope: null,
+511 silly cache add   name: 'grunt-contrib-watch',
+511 silly cache add   rawSpec: '~0.6.1',
+511 silly cache add   spec: '>=0.6.1 <0.7.0',
+511 silly cache add   type: 'range' }
+512 verbose addNamed grunt-contrib-watch@>=0.6.1 <0.7.0
+513 silly addNamed semver.valid null
+514 silly addNamed semver.validRange >=0.6.1 <0.7.0
+515 silly addNameRange { name: 'grunt-contrib-watch',
+515 silly addNameRange   range: '>=0.6.1 <0.7.0',
+515 silly addNameRange   hasData: false }
+516 silly mapToRegistry name grunt-contrib-watch
+517 silly mapToRegistry using default registry
+518 silly mapToRegistry registry https://registry.npmjs.org/
+519 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-watch
+520 verbose addNameRange registry:https://registry.npmjs.org/grunt-contrib-watch not in flight; fetching
+521 silly cache add args [ 'grunt-docco@^0.3.3', null ]
+522 verbose cache add spec grunt-docco@^0.3.3
+523 silly cache add parsed spec { raw: 'grunt-docco@^0.3.3',
+523 silly cache add   scope: null,
+523 silly cache add   name: 'grunt-docco',
+523 silly cache add   rawSpec: '^0.3.3',
+523 silly cache add   spec: '>=0.3.3 <0.4.0',
+523 silly cache add   type: 'range' }
+524 verbose addNamed grunt-docco@>=0.3.3 <0.4.0
+525 silly addNamed semver.valid null
+526 silly addNamed semver.validRange >=0.3.3 <0.4.0
+527 silly addNameRange { name: 'grunt-docco', range: '>=0.3.3 <0.4.0', hasData: false }
+528 silly mapToRegistry name grunt-docco
+529 silly mapToRegistry using default registry
+530 silly mapToRegistry registry https://registry.npmjs.org/
+531 silly mapToRegistry uri https://registry.npmjs.org/grunt-docco
+532 verbose addNameRange registry:https://registry.npmjs.org/grunt-docco not in flight; fetching
+533 silly cache add args [ 'grunt-docker@0.0.10', null ]
+534 verbose cache add spec grunt-docker@0.0.10
+535 silly cache add parsed spec { raw: 'grunt-docker@0.0.10',
+535 silly cache add   scope: null,
+535 silly cache add   name: 'grunt-docker',
+535 silly cache add   rawSpec: '0.0.10',
+535 silly cache add   spec: '0.0.10',
+535 silly cache add   type: 'version' }
+536 verbose addNamed grunt-docker@0.0.10
+537 silly addNamed semver.valid 0.0.10
+538 silly addNamed semver.validRange 0.0.10
+539 silly mapToRegistry name grunt-docker
+540 silly mapToRegistry using default registry
+541 silly mapToRegistry registry https://registry.npmjs.org/
+542 silly mapToRegistry uri https://registry.npmjs.org/grunt-docker
+543 verbose addNameVersion registry:https://registry.npmjs.org/grunt-docker not in flight; fetching
+544 silly cache add args [ 'grunt-dom-munger@^3.4.0', null ]
+545 verbose cache add spec grunt-dom-munger@^3.4.0
+546 silly cache add parsed spec { raw: 'grunt-dom-munger@^3.4.0',
+546 silly cache add   scope: null,
+546 silly cache add   name: 'grunt-dom-munger',
+546 silly cache add   rawSpec: '^3.4.0',
+546 silly cache add   spec: '>=3.4.0 <4.0.0',
+546 silly cache add   type: 'range' }
+547 verbose addNamed grunt-dom-munger@>=3.4.0 <4.0.0
+548 silly addNamed semver.valid null
+549 silly addNamed semver.validRange >=3.4.0 <4.0.0
+550 silly addNameRange { name: 'grunt-dom-munger',
+550 silly addNameRange   range: '>=3.4.0 <4.0.0',
+550 silly addNameRange   hasData: false }
+551 silly mapToRegistry name grunt-dom-munger
+552 silly mapToRegistry using default registry
+553 silly mapToRegistry registry https://registry.npmjs.org/
+554 silly mapToRegistry uri https://registry.npmjs.org/grunt-dom-munger
+555 verbose addNameRange registry:https://registry.npmjs.org/grunt-dom-munger not in flight; fetching
+556 silly cache add args [ 'grunt-env@~0.4.1', null ]
+557 verbose cache add spec grunt-env@~0.4.1
+558 silly cache add parsed spec { raw: 'grunt-env@~0.4.1',
+558 silly cache add   scope: null,
+558 silly cache add   name: 'grunt-env',
+558 silly cache add   rawSpec: '~0.4.1',
+558 silly cache add   spec: '>=0.4.1 <0.5.0',
+558 silly cache add   type: 'range' }
+559 verbose addNamed grunt-env@>=0.4.1 <0.5.0
+560 silly addNamed semver.valid null
+561 silly addNamed semver.validRange >=0.4.1 <0.5.0
+562 silly addNameRange { name: 'grunt-env', range: '>=0.4.1 <0.5.0', hasData: false }
+563 silly mapToRegistry name grunt-env
+564 silly mapToRegistry using default registry
+565 silly mapToRegistry registry https://registry.npmjs.org/
+566 silly mapToRegistry uri https://registry.npmjs.org/grunt-env
+567 verbose addNameRange registry:https://registry.npmjs.org/grunt-env not in flight; fetching
+568 silly cache add args [ 'grunt-express-server@~0.4.17', null ]
+569 verbose cache add spec grunt-express-server@~0.4.17
+570 silly cache add parsed spec { raw: 'grunt-express-server@~0.4.17',
+570 silly cache add   scope: null,
+570 silly cache add   name: 'grunt-express-server',
+570 silly cache add   rawSpec: '~0.4.17',
+570 silly cache add   spec: '>=0.4.17 <0.5.0',
+570 silly cache add   type: 'range' }
+571 verbose addNamed grunt-express-server@>=0.4.17 <0.5.0
+572 silly addNamed semver.valid null
+573 silly addNamed semver.validRange >=0.4.17 <0.5.0
+574 silly addNameRange { name: 'grunt-express-server',
+574 silly addNameRange   range: '>=0.4.17 <0.5.0',
+574 silly addNameRange   hasData: false }
+575 silly mapToRegistry name grunt-express-server
+576 silly mapToRegistry using default registry
+577 silly mapToRegistry registry https://registry.npmjs.org/
+578 silly mapToRegistry uri https://registry.npmjs.org/grunt-express-server
+579 verbose addNameRange registry:https://registry.npmjs.org/grunt-express-server not in flight; fetching
+580 silly cache add args [ 'grunt-google-cdn@~0.4.0', null ]
+581 verbose cache add spec grunt-google-cdn@~0.4.0
+582 silly cache add parsed spec { raw: 'grunt-google-cdn@~0.4.0',
+582 silly cache add   scope: null,
+582 silly cache add   name: 'grunt-google-cdn',
+582 silly cache add   rawSpec: '~0.4.0',
+582 silly cache add   spec: '>=0.4.0 <0.5.0',
+582 silly cache add   type: 'range' }
+583 verbose addNamed grunt-google-cdn@>=0.4.0 <0.5.0
+584 silly addNamed semver.valid null
+585 silly addNamed semver.validRange >=0.4.0 <0.5.0
+586 silly addNameRange { name: 'grunt-google-cdn',
+586 silly addNameRange   range: '>=0.4.0 <0.5.0',
+586 silly addNameRange   hasData: false }
+587 silly mapToRegistry name grunt-google-cdn
+588 silly mapToRegistry using default registry
+589 silly mapToRegistry registry https://registry.npmjs.org/
+590 silly mapToRegistry uri https://registry.npmjs.org/grunt-google-cdn
+591 verbose addNameRange registry:https://registry.npmjs.org/grunt-google-cdn not in flight; fetching
+592 silly cache add args [ 'grunt-karma@~0.8.2', null ]
+593 verbose cache add spec grunt-karma@~0.8.2
+594 silly cache add parsed spec { raw: 'grunt-karma@~0.8.2',
+594 silly cache add   scope: null,
+594 silly cache add   name: 'grunt-karma',
+594 silly cache add   rawSpec: '~0.8.2',
+594 silly cache add   spec: '>=0.8.2 <0.9.0',
+594 silly cache add   type: 'range' }
+595 verbose addNamed grunt-karma@>=0.8.2 <0.9.0
+596 silly addNamed semver.valid null
+597 silly addNamed semver.validRange >=0.8.2 <0.9.0
+598 silly addNameRange { name: 'grunt-karma', range: '>=0.8.2 <0.9.0', hasData: false }
+599 silly mapToRegistry name grunt-karma
+600 silly mapToRegistry using default registry
+601 silly mapToRegistry registry https://registry.npmjs.org/
+602 silly mapToRegistry uri https://registry.npmjs.org/grunt-karma
+603 verbose addNameRange registry:https://registry.npmjs.org/grunt-karma not in flight; fetching
+604 silly cache add args [ 'grunt-mocha-test@~0.10.2', null ]
+605 verbose cache add spec grunt-mocha-test@~0.10.2
+606 silly cache add parsed spec { raw: 'grunt-mocha-test@~0.10.2',
+606 silly cache add   scope: null,
+606 silly cache add   name: 'grunt-mocha-test',
+606 silly cache add   rawSpec: '~0.10.2',
+606 silly cache add   spec: '>=0.10.2 <0.11.0',
+606 silly cache add   type: 'range' }
+607 verbose addNamed grunt-mocha-test@>=0.10.2 <0.11.0
+608 silly addNamed semver.valid null
+609 silly addNamed semver.validRange >=0.10.2 <0.11.0
+610 silly addNameRange { name: 'grunt-mocha-test',
+610 silly addNameRange   range: '>=0.10.2 <0.11.0',
+610 silly addNameRange   hasData: false }
+611 silly mapToRegistry name grunt-mocha-test
+612 silly mapToRegistry using default registry
+613 silly mapToRegistry registry https://registry.npmjs.org/
+614 silly mapToRegistry uri https://registry.npmjs.org/grunt-mocha-test
+615 verbose addNameRange registry:https://registry.npmjs.org/grunt-mocha-test not in flight; fetching
+616 silly cache add args [ 'grunt-newer@~0.7.0', null ]
+617 verbose cache add spec grunt-newer@~0.7.0
+618 silly cache add parsed spec { raw: 'grunt-newer@~0.7.0',
+618 silly cache add   scope: null,
+618 silly cache add   name: 'grunt-newer',
+618 silly cache add   rawSpec: '~0.7.0',
+618 silly cache add   spec: '>=0.7.0 <0.8.0',
+618 silly cache add   type: 'range' }
+619 verbose addNamed grunt-newer@>=0.7.0 <0.8.0
+620 silly addNamed semver.valid null
+621 silly addNamed semver.validRange >=0.7.0 <0.8.0
+622 silly addNameRange { name: 'grunt-newer', range: '>=0.7.0 <0.8.0', hasData: false }
+623 silly mapToRegistry name grunt-newer
+624 silly mapToRegistry using default registry
+625 silly mapToRegistry registry https://registry.npmjs.org/
+626 silly mapToRegistry uri https://registry.npmjs.org/grunt-newer
+627 verbose addNameRange registry:https://registry.npmjs.org/grunt-newer not in flight; fetching
+628 silly cache add args [ 'grunt-ng-annotate@^0.2.3', null ]
+629 verbose cache add spec grunt-ng-annotate@^0.2.3
+630 silly cache add parsed spec { raw: 'grunt-ng-annotate@^0.2.3',
+630 silly cache add   scope: null,
+630 silly cache add   name: 'grunt-ng-annotate',
+630 silly cache add   rawSpec: '^0.2.3',
+630 silly cache add   spec: '>=0.2.3 <0.3.0',
+630 silly cache add   type: 'range' }
+631 verbose addNamed grunt-ng-annotate@>=0.2.3 <0.3.0
+632 silly addNamed semver.valid null
+633 silly addNamed semver.validRange >=0.2.3 <0.3.0
+634 silly addNameRange { name: 'grunt-ng-annotate',
+634 silly addNameRange   range: '>=0.2.3 <0.3.0',
+634 silly addNameRange   hasData: false }
+635 silly mapToRegistry name grunt-ng-annotate
+636 silly mapToRegistry using default registry
+637 silly mapToRegistry registry https://registry.npmjs.org/
+638 silly mapToRegistry uri https://registry.npmjs.org/grunt-ng-annotate
+639 verbose addNameRange registry:https://registry.npmjs.org/grunt-ng-annotate not in flight; fetching
+640 silly cache add args [ 'grunt-node-inspector@~0.1.5', null ]
+641 verbose cache add spec grunt-node-inspector@~0.1.5
+642 silly cache add parsed spec { raw: 'grunt-node-inspector@~0.1.5',
+642 silly cache add   scope: null,
+642 silly cache add   name: 'grunt-node-inspector',
+642 silly cache add   rawSpec: '~0.1.5',
+642 silly cache add   spec: '>=0.1.5 <0.2.0',
+642 silly cache add   type: 'range' }
+643 verbose addNamed grunt-node-inspector@>=0.1.5 <0.2.0
+644 silly addNamed semver.valid null
+645 silly addNamed semver.validRange >=0.1.5 <0.2.0
+646 silly addNameRange { name: 'grunt-node-inspector',
+646 silly addNameRange   range: '>=0.1.5 <0.2.0',
+646 silly addNameRange   hasData: false }
+647 silly mapToRegistry name grunt-node-inspector
+648 silly mapToRegistry using default registry
+649 silly mapToRegistry registry https://registry.npmjs.org/
+650 silly mapToRegistry uri https://registry.npmjs.org/grunt-node-inspector
+651 verbose addNameRange registry:https://registry.npmjs.org/grunt-node-inspector not in flight; fetching
+652 silly cache add args [ 'grunt-nodemon@~0.2.0', null ]
+653 verbose cache add spec grunt-nodemon@~0.2.0
+654 silly cache add parsed spec { raw: 'grunt-nodemon@~0.2.0',
+654 silly cache add   scope: null,
+654 silly cache add   name: 'grunt-nodemon',
+654 silly cache add   rawSpec: '~0.2.0',
+654 silly cache add   spec: '>=0.2.0 <0.3.0',
+654 silly cache add   type: 'range' }
+655 verbose addNamed grunt-nodemon@>=0.2.0 <0.3.0
+656 silly addNamed semver.valid null
+657 silly addNamed semver.validRange >=0.2.0 <0.3.0
+658 silly addNameRange { name: 'grunt-nodemon',
+658 silly addNameRange   range: '>=0.2.0 <0.3.0',
+658 silly addNameRange   hasData: false }
+659 silly mapToRegistry name grunt-nodemon
+660 silly mapToRegistry using default registry
+661 silly mapToRegistry registry https://registry.npmjs.org/
+662 silly mapToRegistry uri https://registry.npmjs.org/grunt-nodemon
+663 verbose addNameRange registry:https://registry.npmjs.org/grunt-nodemon not in flight; fetching
+664 silly cache add args [ 'grunt-open@~0.2.3', null ]
+665 verbose cache add spec grunt-open@~0.2.3
+666 silly cache add parsed spec { raw: 'grunt-open@~0.2.3',
+666 silly cache add   scope: null,
+666 silly cache add   name: 'grunt-open',
+666 silly cache add   rawSpec: '~0.2.3',
+666 silly cache add   spec: '>=0.2.3 <0.3.0',
+666 silly cache add   type: 'range' }
+667 verbose addNamed grunt-open@>=0.2.3 <0.3.0
+668 silly addNamed semver.valid null
+669 silly addNamed semver.validRange >=0.2.3 <0.3.0
+670 silly addNameRange { name: 'grunt-open', range: '>=0.2.3 <0.3.0', hasData: false }
+671 silly mapToRegistry name grunt-open
+672 silly mapToRegistry using default registry
+673 silly mapToRegistry registry https://registry.npmjs.org/
+674 silly mapToRegistry uri https://registry.npmjs.org/grunt-open
+675 verbose addNameRange registry:https://registry.npmjs.org/grunt-open not in flight; fetching
+676 silly cache add args [ 'grunt-protractor-runner@^1.1.0', null ]
+677 verbose cache add spec grunt-protractor-runner@^1.1.0
+678 silly cache add parsed spec { raw: 'grunt-protractor-runner@^1.1.0',
+678 silly cache add   scope: null,
+678 silly cache add   name: 'grunt-protractor-runner',
+678 silly cache add   rawSpec: '^1.1.0',
+678 silly cache add   spec: '>=1.1.0 <2.0.0',
+678 silly cache add   type: 'range' }
+679 verbose addNamed grunt-protractor-runner@>=1.1.0 <2.0.0
+680 silly addNamed semver.valid null
+681 silly addNamed semver.validRange >=1.1.0 <2.0.0
+682 silly addNameRange { name: 'grunt-protractor-runner',
+682 silly addNameRange   range: '>=1.1.0 <2.0.0',
+682 silly addNameRange   hasData: false }
+683 silly mapToRegistry name grunt-protractor-runner
+684 silly mapToRegistry using default registry
+685 silly mapToRegistry registry https://registry.npmjs.org/
+686 silly mapToRegistry uri https://registry.npmjs.org/grunt-protractor-runner
+687 verbose addNameRange registry:https://registry.npmjs.org/grunt-protractor-runner not in flight; fetching
+688 silly cache add args [ 'grunt-rev@~0.1.0', null ]
+689 verbose cache add spec grunt-rev@~0.1.0
+690 silly cache add parsed spec { raw: 'grunt-rev@~0.1.0',
+690 silly cache add   scope: null,
+690 silly cache add   name: 'grunt-rev',
+690 silly cache add   rawSpec: '~0.1.0',
+690 silly cache add   spec: '>=0.1.0 <0.2.0',
+690 silly cache add   type: 'range' }
+691 verbose addNamed grunt-rev@>=0.1.0 <0.2.0
+692 silly addNamed semver.valid null
+693 silly addNamed semver.validRange >=0.1.0 <0.2.0
+694 silly addNameRange { name: 'grunt-rev', range: '>=0.1.0 <0.2.0', hasData: false }
+695 silly mapToRegistry name grunt-rev
+696 silly mapToRegistry using default registry
+697 silly mapToRegistry registry https://registry.npmjs.org/
+698 silly mapToRegistry uri https://registry.npmjs.org/grunt-rev
+699 verbose addNameRange registry:https://registry.npmjs.org/grunt-rev not in flight; fetching
+700 silly cache add args [ 'grunt-svgmin@~0.4.0', null ]
+701 verbose cache add spec grunt-svgmin@~0.4.0
+702 silly cache add parsed spec { raw: 'grunt-svgmin@~0.4.0',
+702 silly cache add   scope: null,
+702 silly cache add   name: 'grunt-svgmin',
+702 silly cache add   rawSpec: '~0.4.0',
+702 silly cache add   spec: '>=0.4.0 <0.5.0',
+702 silly cache add   type: 'range' }
+703 verbose addNamed grunt-svgmin@>=0.4.0 <0.5.0
+704 silly addNamed semver.valid null
+705 silly addNamed semver.validRange >=0.4.0 <0.5.0
+706 silly addNameRange { name: 'grunt-svgmin', range: '>=0.4.0 <0.5.0', hasData: false }
+707 silly mapToRegistry name grunt-svgmin
+708 silly mapToRegistry using default registry
+709 silly mapToRegistry registry https://registry.npmjs.org/
+710 silly mapToRegistry uri https://registry.npmjs.org/grunt-svgmin
+711 verbose addNameRange registry:https://registry.npmjs.org/grunt-svgmin not in flight; fetching
+712 silly cache add args [ 'grunt-usemin@~2.1.1', null ]
+713 verbose cache add spec grunt-usemin@~2.1.1
+714 silly cache add parsed spec { raw: 'grunt-usemin@~2.1.1',
+714 silly cache add   scope: null,
+714 silly cache add   name: 'grunt-usemin',
+714 silly cache add   rawSpec: '~2.1.1',
+714 silly cache add   spec: '>=2.1.1 <2.2.0',
+714 silly cache add   type: 'range' }
+715 verbose addNamed grunt-usemin@>=2.1.1 <2.2.0
+716 silly addNamed semver.valid null
+717 silly addNamed semver.validRange >=2.1.1 <2.2.0
+718 silly addNameRange { name: 'grunt-usemin', range: '>=2.1.1 <2.2.0', hasData: false }
+719 silly mapToRegistry name grunt-usemin
+720 silly mapToRegistry using default registry
+721 silly mapToRegistry registry https://registry.npmjs.org/
+722 silly mapToRegistry uri https://registry.npmjs.org/grunt-usemin
+723 verbose addNameRange registry:https://registry.npmjs.org/grunt-usemin not in flight; fetching
+724 silly cache add args [ 'grunt-wiredep@~1.8.0', null ]
+725 verbose cache add spec grunt-wiredep@~1.8.0
+726 silly cache add parsed spec { raw: 'grunt-wiredep@~1.8.0',
+726 silly cache add   scope: null,
+726 silly cache add   name: 'grunt-wiredep',
+726 silly cache add   rawSpec: '~1.8.0',
+726 silly cache add   spec: '>=1.8.0 <1.9.0',
+726 silly cache add   type: 'range' }
+727 verbose addNamed grunt-wiredep@>=1.8.0 <1.9.0
+728 silly addNamed semver.valid null
+729 silly addNamed semver.validRange >=1.8.0 <1.9.0
+730 silly addNameRange { name: 'grunt-wiredep',
+730 silly addNameRange   range: '>=1.8.0 <1.9.0',
+730 silly addNameRange   hasData: false }
+731 silly mapToRegistry name grunt-wiredep
+732 silly mapToRegistry using default registry
+733 silly mapToRegistry registry https://registry.npmjs.org/
+734 silly mapToRegistry uri https://registry.npmjs.org/grunt-wiredep
+735 verbose addNameRange registry:https://registry.npmjs.org/grunt-wiredep not in flight; fetching
+736 silly cache add args [ 'jit-grunt@^0.5.0', null ]
+737 verbose cache add spec jit-grunt@^0.5.0
+738 silly cache add parsed spec { raw: 'jit-grunt@^0.5.0',
+738 silly cache add   scope: null,
+738 silly cache add   name: 'jit-grunt',
+738 silly cache add   rawSpec: '^0.5.0',
+738 silly cache add   spec: '>=0.5.0 <0.6.0',
+738 silly cache add   type: 'range' }
+739 verbose addNamed jit-grunt@>=0.5.0 <0.6.0
+740 silly addNamed semver.valid null
+741 silly addNamed semver.validRange >=0.5.0 <0.6.0
+742 silly addNameRange { name: 'jit-grunt', range: '>=0.5.0 <0.6.0', hasData: false }
+743 silly mapToRegistry name jit-grunt
+744 silly mapToRegistry using default registry
+745 silly mapToRegistry registry https://registry.npmjs.org/
+746 silly mapToRegistry uri https://registry.npmjs.org/jit-grunt
+747 verbose addNameRange registry:https://registry.npmjs.org/jit-grunt not in flight; fetching
+748 silly cache add args [ 'jshint-stylish@~0.1.5', null ]
+749 verbose cache add spec jshint-stylish@~0.1.5
+750 silly cache add parsed spec { raw: 'jshint-stylish@~0.1.5',
+750 silly cache add   scope: null,
+750 silly cache add   name: 'jshint-stylish',
+750 silly cache add   rawSpec: '~0.1.5',
+750 silly cache add   spec: '>=0.1.5 <0.2.0',
+750 silly cache add   type: 'range' }
+751 verbose addNamed jshint-stylish@>=0.1.5 <0.2.0
+752 silly addNamed semver.valid null
+753 silly addNamed semver.validRange >=0.1.5 <0.2.0
+754 silly addNameRange { name: 'jshint-stylish',
+754 silly addNameRange   range: '>=0.1.5 <0.2.0',
+754 silly addNameRange   hasData: false }
+755 silly mapToRegistry name jshint-stylish
+756 silly mapToRegistry using default registry
+757 silly mapToRegistry registry https://registry.npmjs.org/
+758 silly mapToRegistry uri https://registry.npmjs.org/jshint-stylish
+759 verbose addNameRange registry:https://registry.npmjs.org/jshint-stylish not in flight; fetching
+760 silly cache add args [ 'karma@~0.12.9', null ]
+761 verbose cache add spec karma@~0.12.9
+762 silly cache add parsed spec { raw: 'karma@~0.12.9',
+762 silly cache add   scope: null,
+762 silly cache add   name: 'karma',
+762 silly cache add   rawSpec: '~0.12.9',
+762 silly cache add   spec: '>=0.12.9 <0.13.0',
+762 silly cache add   type: 'range' }
+763 verbose addNamed karma@>=0.12.9 <0.13.0
+764 silly addNamed semver.valid null
+765 silly addNamed semver.validRange >=0.12.9 <0.13.0
+766 silly addNameRange { name: 'karma', range: '>=0.12.9 <0.13.0', hasData: false }
+767 silly mapToRegistry name karma
+768 silly mapToRegistry using default registry
+769 silly mapToRegistry registry https://registry.npmjs.org/
+770 silly mapToRegistry uri https://registry.npmjs.org/karma
+771 verbose addNameRange registry:https://registry.npmjs.org/karma not in flight; fetching
+772 silly cache add args [ 'karma-chrome-launcher@~0.1.3', null ]
+773 verbose cache add spec karma-chrome-launcher@~0.1.3
+774 silly cache add parsed spec { raw: 'karma-chrome-launcher@~0.1.3',
+774 silly cache add   scope: null,
+774 silly cache add   name: 'karma-chrome-launcher',
+774 silly cache add   rawSpec: '~0.1.3',
+774 silly cache add   spec: '>=0.1.3 <0.2.0',
+774 silly cache add   type: 'range' }
+775 verbose addNamed karma-chrome-launcher@>=0.1.3 <0.2.0
+776 silly addNamed semver.valid null
+777 silly addNamed semver.validRange >=0.1.3 <0.2.0
+778 silly addNameRange { name: 'karma-chrome-launcher',
+778 silly addNameRange   range: '>=0.1.3 <0.2.0',
+778 silly addNameRange   hasData: false }
+779 silly mapToRegistry name karma-chrome-launcher
+780 silly mapToRegistry using default registry
+781 silly mapToRegistry registry https://registry.npmjs.org/
+782 silly mapToRegistry uri https://registry.npmjs.org/karma-chrome-launcher
+783 verbose addNameRange registry:https://registry.npmjs.org/karma-chrome-launcher not in flight; fetching
+784 silly cache add args [ 'karma-coffee-preprocessor@~0.2.1', null ]
+785 verbose cache add spec karma-coffee-preprocessor@~0.2.1
+786 silly cache add parsed spec { raw: 'karma-coffee-preprocessor@~0.2.1',
+786 silly cache add   scope: null,
+786 silly cache add   name: 'karma-coffee-preprocessor',
+786 silly cache add   rawSpec: '~0.2.1',
+786 silly cache add   spec: '>=0.2.1 <0.3.0',
+786 silly cache add   type: 'range' }
+787 verbose addNamed karma-coffee-preprocessor@>=0.2.1 <0.3.0
+788 silly addNamed semver.valid null
+789 silly addNamed semver.validRange >=0.2.1 <0.3.0
+790 silly addNameRange { name: 'karma-coffee-preprocessor',
+790 silly addNameRange   range: '>=0.2.1 <0.3.0',
+790 silly addNameRange   hasData: false }
+791 silly mapToRegistry name karma-coffee-preprocessor
+792 silly mapToRegistry using default registry
+793 silly mapToRegistry registry https://registry.npmjs.org/
+794 silly mapToRegistry uri https://registry.npmjs.org/karma-coffee-preprocessor
+795 verbose addNameRange registry:https://registry.npmjs.org/karma-coffee-preprocessor not in flight; fetching
+796 silly cache add args [ 'karma-firefox-launcher@~0.1.3', null ]
+797 verbose cache add spec karma-firefox-launcher@~0.1.3
+798 silly cache add parsed spec { raw: 'karma-firefox-launcher@~0.1.3',
+798 silly cache add   scope: null,
+798 silly cache add   name: 'karma-firefox-launcher',
+798 silly cache add   rawSpec: '~0.1.3',
+798 silly cache add   spec: '>=0.1.3 <0.2.0',
+798 silly cache add   type: 'range' }
+799 verbose addNamed karma-firefox-launcher@>=0.1.3 <0.2.0
+800 silly addNamed semver.valid null
+801 silly addNamed semver.validRange >=0.1.3 <0.2.0
+802 silly addNameRange { name: 'karma-firefox-launcher',
+802 silly addNameRange   range: '>=0.1.3 <0.2.0',
+802 silly addNameRange   hasData: false }
+803 silly mapToRegistry name karma-firefox-launcher
+804 silly mapToRegistry using default registry
+805 silly mapToRegistry registry https://registry.npmjs.org/
+806 silly mapToRegistry uri https://registry.npmjs.org/karma-firefox-launcher
+807 verbose addNameRange registry:https://registry.npmjs.org/karma-firefox-launcher not in flight; fetching
+808 silly cache add args [ 'karma-html2js-preprocessor@~0.1.0', null ]
+809 verbose cache add spec karma-html2js-preprocessor@~0.1.0
+810 silly cache add parsed spec { raw: 'karma-html2js-preprocessor@~0.1.0',
+810 silly cache add   scope: null,
+810 silly cache add   name: 'karma-html2js-preprocessor',
+810 silly cache add   rawSpec: '~0.1.0',
+810 silly cache add   spec: '>=0.1.0 <0.2.0',
+810 silly cache add   type: 'range' }
+811 verbose addNamed karma-html2js-preprocessor@>=0.1.0 <0.2.0
+812 silly addNamed semver.valid null
+813 silly addNamed semver.validRange >=0.1.0 <0.2.0
+814 silly addNameRange { name: 'karma-html2js-preprocessor',
+814 silly addNameRange   range: '>=0.1.0 <0.2.0',
+814 silly addNameRange   hasData: false }
+815 silly mapToRegistry name karma-html2js-preprocessor
+816 silly mapToRegistry using default registry
+817 silly mapToRegistry registry https://registry.npmjs.org/
+818 silly mapToRegistry uri https://registry.npmjs.org/karma-html2js-preprocessor
+819 verbose addNameRange registry:https://registry.npmjs.org/karma-html2js-preprocessor not in flight; fetching
+820 silly cache add args [ 'karma-jade-preprocessor@0.0.11', null ]
+821 verbose cache add spec karma-jade-preprocessor@0.0.11
+822 silly cache add parsed spec { raw: 'karma-jade-preprocessor@0.0.11',
+822 silly cache add   scope: null,
+822 silly cache add   name: 'karma-jade-preprocessor',
+822 silly cache add   rawSpec: '0.0.11',
+822 silly cache add   spec: '0.0.11',
+822 silly cache add   type: 'version' }
+823 verbose addNamed karma-jade-preprocessor@0.0.11
+824 silly addNamed semver.valid 0.0.11
+825 silly addNamed semver.validRange 0.0.11
+826 silly mapToRegistry name karma-jade-preprocessor
+827 silly mapToRegistry using default registry
+828 silly mapToRegistry registry https://registry.npmjs.org/
+829 silly mapToRegistry uri https://registry.npmjs.org/karma-jade-preprocessor
+830 verbose addNameVersion registry:https://registry.npmjs.org/karma-jade-preprocessor not in flight; fetching
+831 silly cache add args [ 'karma-jasmine@~0.1.5', null ]
+832 verbose cache add spec karma-jasmine@~0.1.5
+833 silly cache add parsed spec { raw: 'karma-jasmine@~0.1.5',
+833 silly cache add   scope: null,
+833 silly cache add   name: 'karma-jasmine',
+833 silly cache add   rawSpec: '~0.1.5',
+833 silly cache add   spec: '>=0.1.5 <0.2.0',
+833 silly cache add   type: 'range' }
+834 verbose addNamed karma-jasmine@>=0.1.5 <0.2.0
+835 silly addNamed semver.valid null
+836 silly addNamed semver.validRange >=0.1.5 <0.2.0
+837 silly addNameRange { name: 'karma-jasmine',
+837 silly addNameRange   range: '>=0.1.5 <0.2.0',
+837 silly addNameRange   hasData: false }
+838 silly mapToRegistry name karma-jasmine
+839 silly mapToRegistry using default registry
+840 silly mapToRegistry registry https://registry.npmjs.org/
+841 silly mapToRegistry uri https://registry.npmjs.org/karma-jasmine
+842 verbose addNameRange registry:https://registry.npmjs.org/karma-jasmine not in flight; fetching
+843 silly cache add args [ 'karma-ng-html2js-preprocessor@~0.1.0', null ]
+844 verbose cache add spec karma-ng-html2js-preprocessor@~0.1.0
+845 silly cache add parsed spec { raw: 'karma-ng-html2js-preprocessor@~0.1.0',
+845 silly cache add   scope: null,
+845 silly cache add   name: 'karma-ng-html2js-preprocessor',
+845 silly cache add   rawSpec: '~0.1.0',
+845 silly cache add   spec: '>=0.1.0 <0.2.0',
+845 silly cache add   type: 'range' }
+846 verbose addNamed karma-ng-html2js-preprocessor@>=0.1.0 <0.2.0
+847 silly addNamed semver.valid null
+848 silly addNamed semver.validRange >=0.1.0 <0.2.0
+849 silly addNameRange { name: 'karma-ng-html2js-preprocessor',
+849 silly addNameRange   range: '>=0.1.0 <0.2.0',
+849 silly addNameRange   hasData: false }
+850 silly mapToRegistry name karma-ng-html2js-preprocessor
+851 silly mapToRegistry using default registry
+852 silly mapToRegistry registry https://registry.npmjs.org/
+853 silly mapToRegistry uri https://registry.npmjs.org/karma-ng-html2js-preprocessor
+854 verbose addNameRange registry:https://registry.npmjs.org/karma-ng-html2js-preprocessor not in flight; fetching
+855 silly cache add args [ 'karma-ng-jade2js-preprocessor@^0.1.2', null ]
+856 verbose cache add spec karma-ng-jade2js-preprocessor@^0.1.2
+857 silly cache add parsed spec { raw: 'karma-ng-jade2js-preprocessor@^0.1.2',
+857 silly cache add   scope: null,
+857 silly cache add   name: 'karma-ng-jade2js-preprocessor',
+857 silly cache add   rawSpec: '^0.1.2',
+857 silly cache add   spec: '>=0.1.2 <0.2.0',
+857 silly cache add   type: 'range' }
+858 verbose addNamed karma-ng-jade2js-preprocessor@>=0.1.2 <0.2.0
+859 silly addNamed semver.valid null
+860 silly addNamed semver.validRange >=0.1.2 <0.2.0
+861 silly addNameRange { name: 'karma-ng-jade2js-preprocessor',
+861 silly addNameRange   range: '>=0.1.2 <0.2.0',
+861 silly addNameRange   hasData: false }
+862 silly mapToRegistry name karma-ng-jade2js-preprocessor
+863 silly mapToRegistry using default registry
+864 silly mapToRegistry registry https://registry.npmjs.org/
+865 silly mapToRegistry uri https://registry.npmjs.org/karma-ng-jade2js-preprocessor
+866 verbose addNameRange registry:https://registry.npmjs.org/karma-ng-jade2js-preprocessor not in flight; fetching
+867 silly cache add args [ 'karma-ng-scenario@~0.1.0', null ]
+868 verbose cache add spec karma-ng-scenario@~0.1.0
+869 silly cache add parsed spec { raw: 'karma-ng-scenario@~0.1.0',
+869 silly cache add   scope: null,
+869 silly cache add   name: 'karma-ng-scenario',
+869 silly cache add   rawSpec: '~0.1.0',
+869 silly cache add   spec: '>=0.1.0 <0.2.0',
+869 silly cache add   type: 'range' }
+870 verbose addNamed karma-ng-scenario@>=0.1.0 <0.2.0
+871 silly addNamed semver.valid null
+872 silly addNamed semver.validRange >=0.1.0 <0.2.0
+873 silly addNameRange { name: 'karma-ng-scenario',
+873 silly addNameRange   range: '>=0.1.0 <0.2.0',
+873 silly addNameRange   hasData: false }
+874 silly mapToRegistry name karma-ng-scenario
+875 silly mapToRegistry using default registry
+876 silly mapToRegistry registry https://registry.npmjs.org/
+877 silly mapToRegistry uri https://registry.npmjs.org/karma-ng-scenario
+878 verbose addNameRange registry:https://registry.npmjs.org/karma-ng-scenario not in flight; fetching
+879 silly cache add args [ 'karma-phantomjs-launcher@~0.1.4', null ]
+880 verbose cache add spec karma-phantomjs-launcher@~0.1.4
+881 silly cache add parsed spec { raw: 'karma-phantomjs-launcher@~0.1.4',
+881 silly cache add   scope: null,
+881 silly cache add   name: 'karma-phantomjs-launcher',
+881 silly cache add   rawSpec: '~0.1.4',
+881 silly cache add   spec: '>=0.1.4 <0.2.0',
+881 silly cache add   type: 'range' }
+882 verbose addNamed karma-phantomjs-launcher@>=0.1.4 <0.2.0
+883 silly addNamed semver.valid null
+884 silly addNamed semver.validRange >=0.1.4 <0.2.0
+885 silly addNameRange { name: 'karma-phantomjs-launcher',
+885 silly addNameRange   range: '>=0.1.4 <0.2.0',
+885 silly addNameRange   hasData: false }
+886 silly mapToRegistry name karma-phantomjs-launcher
+887 silly mapToRegistry using default registry
+888 silly mapToRegistry registry https://registry.npmjs.org/
+889 silly mapToRegistry uri https://registry.npmjs.org/karma-phantomjs-launcher
+890 verbose addNameRange registry:https://registry.npmjs.org/karma-phantomjs-launcher not in flight; fetching
+891 silly cache add args [ 'karma-requirejs@~0.2.1', null ]
+892 verbose cache add spec karma-requirejs@~0.2.1
+893 silly cache add parsed spec { raw: 'karma-requirejs@~0.2.1',
+893 silly cache add   scope: null,
+893 silly cache add   name: 'karma-requirejs',
+893 silly cache add   rawSpec: '~0.2.1',
+893 silly cache add   spec: '>=0.2.1 <0.3.0',
+893 silly cache add   type: 'range' }
+894 verbose addNamed karma-requirejs@>=0.2.1 <0.3.0
+895 silly addNamed semver.valid null
+896 silly addNamed semver.validRange >=0.2.1 <0.3.0
+897 silly addNameRange { name: 'karma-requirejs',
+897 silly addNameRange   range: '>=0.2.1 <0.3.0',
+897 silly addNameRange   hasData: false }
+898 silly mapToRegistry name karma-requirejs
+899 silly mapToRegistry using default registry
+900 silly mapToRegistry registry https://registry.npmjs.org/
+901 silly mapToRegistry uri https://registry.npmjs.org/karma-requirejs
+902 verbose addNameRange registry:https://registry.npmjs.org/karma-requirejs not in flight; fetching
+903 silly cache add args [ 'karma-script-launcher@~0.1.0', null ]
+904 verbose cache add spec karma-script-launcher@~0.1.0
+905 silly cache add parsed spec { raw: 'karma-script-launcher@~0.1.0',
+905 silly cache add   scope: null,
+905 silly cache add   name: 'karma-script-launcher',
+905 silly cache add   rawSpec: '~0.1.0',
+905 silly cache add   spec: '>=0.1.0 <0.2.0',
+905 silly cache add   type: 'range' }
+906 verbose addNamed karma-script-launcher@>=0.1.0 <0.2.0
+907 silly addNamed semver.valid null
+908 silly addNamed semver.validRange >=0.1.0 <0.2.0
+909 silly addNameRange { name: 'karma-script-launcher',
+909 silly addNameRange   range: '>=0.1.0 <0.2.0',
+909 silly addNameRange   hasData: false }
+910 silly mapToRegistry name karma-script-launcher
+911 silly mapToRegistry using default registry
+912 silly mapToRegistry registry https://registry.npmjs.org/
+913 silly mapToRegistry uri https://registry.npmjs.org/karma-script-launcher
+914 verbose addNameRange registry:https://registry.npmjs.org/karma-script-launcher not in flight; fetching
+915 silly cache add args [ 'open@~0.0.4', null ]
+916 verbose cache add spec open@~0.0.4
+917 silly cache add parsed spec { raw: 'open@~0.0.4',
+917 silly cache add   scope: null,
+917 silly cache add   name: 'open',
+917 silly cache add   rawSpec: '~0.0.4',
+917 silly cache add   spec: '>=0.0.4 <0.1.0',
+917 silly cache add   type: 'range' }
+918 verbose addNamed open@>=0.0.4 <0.1.0
+919 silly addNamed semver.valid null
+920 silly addNamed semver.validRange >=0.0.4 <0.1.0
+921 silly addNameRange { name: 'open', range: '>=0.0.4 <0.1.0', hasData: false }
+922 silly mapToRegistry name open
+923 silly mapToRegistry using default registry
+924 silly mapToRegistry registry https://registry.npmjs.org/
+925 silly mapToRegistry uri https://registry.npmjs.org/open
+926 verbose addNameRange registry:https://registry.npmjs.org/open not in flight; fetching
+927 silly cache add args [ 'requirejs@~2.1.11', null ]
+928 verbose cache add spec requirejs@~2.1.11
+929 silly cache add parsed spec { raw: 'requirejs@~2.1.11',
+929 silly cache add   scope: null,
+929 silly cache add   name: 'requirejs',
+929 silly cache add   rawSpec: '~2.1.11',
+929 silly cache add   spec: '>=2.1.11 <2.2.0',
+929 silly cache add   type: 'range' }
+930 verbose addNamed requirejs@>=2.1.11 <2.2.0
+931 silly addNamed semver.valid null
+932 silly addNamed semver.validRange >=2.1.11 <2.2.0
+933 silly addNameRange { name: 'requirejs', range: '>=2.1.11 <2.2.0', hasData: false }
+934 silly mapToRegistry name requirejs
+935 silly mapToRegistry using default registry
+936 silly mapToRegistry registry https://registry.npmjs.org/
+937 silly mapToRegistry uri https://registry.npmjs.org/requirejs
+938 verbose addNameRange registry:https://registry.npmjs.org/requirejs not in flight; fetching
+939 silly cache add args [ 'should@~3.3.1', null ]
+940 verbose cache add spec should@~3.3.1
+941 silly cache add parsed spec { raw: 'should@~3.3.1',
+941 silly cache add   scope: null,
+941 silly cache add   name: 'should',
+941 silly cache add   rawSpec: '~3.3.1',
+941 silly cache add   spec: '>=3.3.1 <3.4.0',
+941 silly cache add   type: 'range' }
+942 verbose addNamed should@>=3.3.1 <3.4.0
+943 silly addNamed semver.valid null
+944 silly addNamed semver.validRange >=3.3.1 <3.4.0
+945 silly addNameRange { name: 'should', range: '>=3.3.1 <3.4.0', hasData: false }
+946 silly mapToRegistry name should
+947 silly mapToRegistry using default registry
+948 silly mapToRegistry registry https://registry.npmjs.org/
+949 silly mapToRegistry uri https://registry.npmjs.org/should
+950 verbose addNameRange registry:https://registry.npmjs.org/should not in flight; fetching
+951 silly cache add args [ 'supertest@~0.11.0', null ]
+952 verbose cache add spec supertest@~0.11.0
+953 silly cache add parsed spec { raw: 'supertest@~0.11.0',
+953 silly cache add   scope: null,
+953 silly cache add   name: 'supertest',
+953 silly cache add   rawSpec: '~0.11.0',
+953 silly cache add   spec: '>=0.11.0 <0.12.0',
+953 silly cache add   type: 'range' }
+954 verbose addNamed supertest@>=0.11.0 <0.12.0
+955 silly addNamed semver.valid null
+956 silly addNamed semver.validRange >=0.11.0 <0.12.0
+957 silly addNameRange { name: 'supertest', range: '>=0.11.0 <0.12.0', hasData: false }
+958 silly mapToRegistry name supertest
+959 silly mapToRegistry using default registry
+960 silly mapToRegistry registry https://registry.npmjs.org/
+961 silly mapToRegistry uri https://registry.npmjs.org/supertest
+962 verbose addNameRange registry:https://registry.npmjs.org/supertest not in flight; fetching
+963 silly cache add args [ 'time-grunt@~0.3.1', null ]
+964 verbose cache add spec time-grunt@~0.3.1
+965 silly cache add parsed spec { raw: 'time-grunt@~0.3.1',
+965 silly cache add   scope: null,
+965 silly cache add   name: 'time-grunt',
+965 silly cache add   rawSpec: '~0.3.1',
+965 silly cache add   spec: '>=0.3.1 <0.4.0',
+965 silly cache add   type: 'range' }
+966 verbose addNamed time-grunt@>=0.3.1 <0.4.0
+967 silly addNamed semver.valid null
+968 silly addNamed semver.validRange >=0.3.1 <0.4.0
+969 silly addNameRange { name: 'time-grunt', range: '>=0.3.1 <0.4.0', hasData: false }
+970 silly mapToRegistry name time-grunt
+971 silly mapToRegistry using default registry
+972 silly mapToRegistry registry https://registry.npmjs.org/
+973 silly mapToRegistry uri https://registry.npmjs.org/time-grunt
+974 verbose addNameRange registry:https://registry.npmjs.org/time-grunt not in flight; fetching
+975 silly cache add args [ 'body-parser@~1.5.0', null ]
+976 verbose cache add spec body-parser@~1.5.0
+977 silly cache add parsed spec { raw: 'body-parser@~1.5.0',
+977 silly cache add   scope: null,
+977 silly cache add   name: 'body-parser',
+977 silly cache add   rawSpec: '~1.5.0',
+977 silly cache add   spec: '>=1.5.0 <1.6.0',
+977 silly cache add   type: 'range' }
+978 verbose addNamed body-parser@>=1.5.0 <1.6.0
+979 silly addNamed semver.valid null
+980 silly addNamed semver.validRange >=1.5.0 <1.6.0
+981 silly addNameRange { name: 'body-parser', range: '>=1.5.0 <1.6.0', hasData: false }
+982 silly mapToRegistry name body-parser
+983 silly mapToRegistry using default registry
+984 silly mapToRegistry registry https://registry.npmjs.org/
+985 silly mapToRegistry uri https://registry.npmjs.org/body-parser
+986 verbose addNameRange registry:https://registry.npmjs.org/body-parser not in flight; fetching
+987 silly cache add args [ 'chokidar@^1.0.3', null ]
+988 verbose cache add spec chokidar@^1.0.3
+989 silly cache add parsed spec { raw: 'chokidar@^1.0.3',
+989 silly cache add   scope: null,
+989 silly cache add   name: 'chokidar',
+989 silly cache add   rawSpec: '^1.0.3',
+989 silly cache add   spec: '>=1.0.3 <2.0.0',
+989 silly cache add   type: 'range' }
+990 verbose addNamed chokidar@>=1.0.3 <2.0.0
+991 silly addNamed semver.valid null
+992 silly addNamed semver.validRange >=1.0.3 <2.0.0
+993 silly addNameRange { name: 'chokidar', range: '>=1.0.3 <2.0.0', hasData: false }
+994 silly mapToRegistry name chokidar
+995 silly mapToRegistry using default registry
+996 silly mapToRegistry registry https://registry.npmjs.org/
+997 silly mapToRegistry uri https://registry.npmjs.org/chokidar
+998 verbose addNameRange registry:https://registry.npmjs.org/chokidar not in flight; fetching
+999 silly cache add args [ 'composable-middleware@^0.3.0', null ]
+1000 verbose cache add spec composable-middleware@^0.3.0
+1001 silly cache add parsed spec { raw: 'composable-middleware@^0.3.0',
+1001 silly cache add   scope: null,
+1001 silly cache add   name: 'composable-middleware',
+1001 silly cache add   rawSpec: '^0.3.0',
+1001 silly cache add   spec: '>=0.3.0 <0.4.0',
+1001 silly cache add   type: 'range' }
+1002 verbose addNamed composable-middleware@>=0.3.0 <0.4.0
+1003 silly addNamed semver.valid null
+1004 silly addNamed semver.validRange >=0.3.0 <0.4.0
+1005 silly addNameRange { name: 'composable-middleware',
+1005 silly addNameRange   range: '>=0.3.0 <0.4.0',
+1005 silly addNameRange   hasData: false }
+1006 silly mapToRegistry name composable-middleware
+1007 silly mapToRegistry using default registry
+1008 silly mapToRegistry registry https://registry.npmjs.org/
+1009 silly mapToRegistry uri https://registry.npmjs.org/composable-middleware
+1010 verbose addNameRange registry:https://registry.npmjs.org/composable-middleware not in flight; fetching
+1011 silly cache add args [ 'compression@~1.0.1', null ]
+1012 verbose cache add spec compression@~1.0.1
+1013 silly cache add parsed spec { raw: 'compression@~1.0.1',
+1013 silly cache add   scope: null,
+1013 silly cache add   name: 'compression',
+1013 silly cache add   rawSpec: '~1.0.1',
+1013 silly cache add   spec: '>=1.0.1 <1.1.0',
+1013 silly cache add   type: 'range' }
+1014 verbose addNamed compression@>=1.0.1 <1.1.0
+1015 silly addNamed semver.valid null
+1016 silly addNamed semver.validRange >=1.0.1 <1.1.0
+1017 silly addNameRange { name: 'compression', range: '>=1.0.1 <1.1.0', hasData: false }
+1018 silly mapToRegistry name compression
+1019 silly mapToRegistry using default registry
+1020 silly mapToRegistry registry https://registry.npmjs.org/
+1021 silly mapToRegistry uri https://registry.npmjs.org/compression
+1022 verbose addNameRange registry:https://registry.npmjs.org/compression not in flight; fetching
+1023 silly cache add args [ 'connect-mongo@^0.4.1', null ]
+1024 verbose cache add spec connect-mongo@^0.4.1
+1025 silly cache add parsed spec { raw: 'connect-mongo@^0.4.1',
+1025 silly cache add   scope: null,
+1025 silly cache add   name: 'connect-mongo',
+1025 silly cache add   rawSpec: '^0.4.1',
+1025 silly cache add   spec: '>=0.4.1 <0.5.0',
+1025 silly cache add   type: 'range' }
+1026 verbose addNamed connect-mongo@>=0.4.1 <0.5.0
+1027 silly addNamed semver.valid null
+1028 silly addNamed semver.validRange >=0.4.1 <0.5.0
+1029 silly addNameRange { name: 'connect-mongo',
+1029 silly addNameRange   range: '>=0.4.1 <0.5.0',
+1029 silly addNameRange   hasData: false }
+1030 silly mapToRegistry name connect-mongo
+1031 silly mapToRegistry using default registry
+1032 silly mapToRegistry registry https://registry.npmjs.org/
+1033 silly mapToRegistry uri https://registry.npmjs.org/connect-mongo
+1034 verbose addNameRange registry:https://registry.npmjs.org/connect-mongo not in flight; fetching
+1035 silly cache add args [ 'cookie-parser@~1.0.1', null ]
+1036 verbose cache add spec cookie-parser@~1.0.1
+1037 silly cache add parsed spec { raw: 'cookie-parser@~1.0.1',
+1037 silly cache add   scope: null,
+1037 silly cache add   name: 'cookie-parser',
+1037 silly cache add   rawSpec: '~1.0.1',
+1037 silly cache add   spec: '>=1.0.1 <1.1.0',
+1037 silly cache add   type: 'range' }
+1038 verbose addNamed cookie-parser@>=1.0.1 <1.1.0
+1039 silly addNamed semver.valid null
+1040 silly addNamed semver.validRange >=1.0.1 <1.1.0
+1041 silly addNameRange { name: 'cookie-parser',
+1041 silly addNameRange   range: '>=1.0.1 <1.1.0',
+1041 silly addNameRange   hasData: false }
+1042 silly mapToRegistry name cookie-parser
+1043 silly mapToRegistry using default registry
+1044 silly mapToRegistry registry https://registry.npmjs.org/
+1045 silly mapToRegistry uri https://registry.npmjs.org/cookie-parser
+1046 verbose addNameRange registry:https://registry.npmjs.org/cookie-parser not in flight; fetching
+1047 verbose request uri https://registry.npmjs.org/fs-finder
+1048 verbose request no auth needed
+1049 info attempt registry request try #1 at 10:45:56 AM
+1050 verbose request id e8cae9c551e05e47
+1051 http request GET https://registry.npmjs.org/fs-finder
+1052 verbose request uri https://registry.npmjs.org/jade-browser-middleware
+1053 verbose request no auth needed
+1054 info attempt registry request try #1 at 10:45:56 AM
+1055 http request GET https://registry.npmjs.org/jade-browser-middleware
+1056 verbose request uri https://registry.npmjs.org/mongoose-text-search
+1057 verbose request no auth needed
+1058 info attempt registry request try #1 at 10:45:56 AM
+1059 http request GET https://registry.npmjs.org/mongoose-text-search
+1060 silly cache add parsed spec { raw: 'passport-facebook@latest',
+1060 silly cache add   scope: null,
+1060 silly cache add   name: 'passport-facebook',
+1060 silly cache add   rawSpec: 'latest',
+1060 silly cache add   spec: 'latest',
+1060 silly cache add   type: 'tag' }
+1061 verbose addNamed passport-facebook@latest
+1062 silly addNamed semver.valid null
+1063 silly addNamed semver.validRange null
+1064 info addNameTag [ 'passport-facebook', 'latest' ]
+1065 silly mapToRegistry name passport-facebook
+1066 silly mapToRegistry using default registry
+1067 silly mapToRegistry registry https://registry.npmjs.org/
+1068 silly mapToRegistry uri https://registry.npmjs.org/passport-facebook
+1069 verbose addNameTag registry:https://registry.npmjs.org/passport-facebook not in flight; fetching
+1070 silly cache add parsed spec { raw: 'passport-google-oauth@latest',
+1070 silly cache add   scope: null,
+1070 silly cache add   name: 'passport-google-oauth',
+1070 silly cache add   rawSpec: 'latest',
+1070 silly cache add   spec: 'latest',
+1070 silly cache add   type: 'tag' }
+1071 verbose addNamed passport-google-oauth@latest
+1072 silly addNamed semver.valid null
+1073 silly addNamed semver.validRange null
+1074 info addNameTag [ 'passport-google-oauth', 'latest' ]
+1075 silly mapToRegistry name passport-google-oauth
+1076 silly mapToRegistry using default registry
+1077 silly mapToRegistry registry https://registry.npmjs.org/
+1078 silly mapToRegistry uri https://registry.npmjs.org/passport-google-oauth
+1079 verbose addNameTag registry:https://registry.npmjs.org/passport-google-oauth not in flight; fetching
+1080 silly cache add parsed spec { raw: 'passport-twitter@latest',
+1080 silly cache add   scope: null,
+1080 silly cache add   name: 'passport-twitter',
+1080 silly cache add   rawSpec: 'latest',
+1080 silly cache add   spec: 'latest',
+1080 silly cache add   type: 'tag' }
+1081 verbose addNamed passport-twitter@latest
+1082 silly addNamed semver.valid null
+1083 silly addNamed semver.validRange null
+1084 info addNameTag [ 'passport-twitter', 'latest' ]
+1085 silly mapToRegistry name passport-twitter
+1086 silly mapToRegistry using default registry
+1087 silly mapToRegistry registry https://registry.npmjs.org/
+1088 silly mapToRegistry uri https://registry.npmjs.org/passport-twitter
+1089 verbose addNameTag registry:https://registry.npmjs.org/passport-twitter not in flight; fetching
+1090 verbose request uri https://registry.npmjs.org/xml-to-json
+1091 verbose request no auth needed
+1092 info attempt registry request try #1 at 10:45:56 AM
+1093 http request GET https://registry.npmjs.org/xml-to-json
+1094 silly cache add parsed spec { raw: 'grunt-build-control@git+https://github.com/DaftMonk/grunt-build-control',
+1094 silly cache add   scope: null,
+1094 silly cache add   name: 'grunt-build-control',
+1094 silly cache add   rawSpec: 'git+https://github.com/DaftMonk/grunt-build-control',
+1094 silly cache add   spec: 'git+ssh://git@github.com/DaftMonk/grunt-build-control.git',
+1094 silly cache add   type: 'hosted',
+1094 silly cache add   hosted:
+1094 silly cache add    { type: 'github',
+1094 silly cache add      ssh: 'git@github.com:DaftMonk/grunt-build-control.git',
+1094 silly cache add      sshUrl: 'git+ssh://git@github.com/DaftMonk/grunt-build-control.git',
+1094 silly cache add      httpsUrl: 'https://github.com/DaftMonk/grunt-build-control.git',
+1094 silly cache add      directUrl: 'https://raw.githubusercontent.com/DaftMonk/grunt-build-control/master/package.json' } }
+1095 info maybeGithub Attempting git+https://github.com/DaftMonk/grunt-build-control from git://github.com/DaftMonk/grunt-build-control.git
+1096 verbose addRemoteGit git-github-com-DaftMonk-grunt-build-control-git-2e0cd8b8 not in flight; caching
+1097 silly cache add parsed spec { raw: 'grunt-contrib-stylus@latest',
+1097 silly cache add   scope: null,
+1097 silly cache add   name: 'grunt-contrib-stylus',
+1097 silly cache add   rawSpec: 'latest',
+1097 silly cache add   spec: 'latest',
+1097 silly cache add   type: 'tag' }
+1098 verbose addNamed grunt-contrib-stylus@latest
+1099 silly addNamed semver.valid null
+1100 silly addNamed semver.validRange null
+1101 info addNameTag [ 'grunt-contrib-stylus', 'latest' ]
+1102 silly mapToRegistry name grunt-contrib-stylus
+1103 silly mapToRegistry using default registry
+1104 silly mapToRegistry registry https://registry.npmjs.org/
+1105 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-stylus
+1106 verbose addNameTag registry:https://registry.npmjs.org/grunt-contrib-stylus not in flight; fetching
+1107 verbose request uri https://registry.npmjs.org/grunt-docker
+1108 verbose request no auth needed
+1109 info attempt registry request try #1 at 10:45:56 AM
+1110 http request GET https://registry.npmjs.org/grunt-docker
+1111 http 200 https://registry.npmjs.org/xml-to-json
+1112 silly get cb [ 200,
+1112 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1112 silly get     etag: '"AA9PLI6KECQODWRA0ODX36JC8"',
+1112 silly get     'content-type': 'application/json',
+1112 silly get     'cache-control': 'max-age=60',
+1112 silly get     'content-length': '4003',
+1112 silly get     'accept-ranges': 'bytes',
+1112 silly get     date: 'Thu, 23 Jul 2015 17:45:56 GMT',
+1112 silly get     via: '1.1 varnish',
+1112 silly get     age: '0',
+1112 silly get     connection: 'keep-alive',
+1112 silly get     'x-served-by': 'cache-lax1433-LAX',
+1112 silly get     'x-cache': 'MISS',
+1112 silly get     'x-cache-hits': '0',
+1112 silly get     'x-timer': 'S1437673556.700383,VS0,VE51',
+1112 silly get     vary: 'Accept' } ]
+1113 verbose get saving xml-to-json to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\xml-to-json\.cache.json
+1114 http 200 https://registry.npmjs.org/jade-browser-middleware
+1115 silly get cb [ 200,
+1115 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1115 silly get     etag: '"4HHS7WT4MV3NPLNX1HW4P15NO"',
+1115 silly get     'content-type': 'application/json',
+1115 silly get     'cache-control': 'max-age=60',
+1115 silly get     'content-length': '13977',
+1115 silly get     'accept-ranges': 'bytes',
+1115 silly get     date: 'Thu, 23 Jul 2015 17:45:56 GMT',
+1115 silly get     via: '1.1 varnish',
+1115 silly get     age: '0',
+1115 silly get     connection: 'keep-alive',
+1115 silly get     'x-served-by': 'cache-lax1432-LAX',
+1115 silly get     'x-cache': 'MISS',
+1115 silly get     'x-cache-hits': '0',
+1115 silly get     'x-timer': 'S1437673556.738602,VS0,VE52',
+1115 silly get     vary: 'Accept' } ]
+1116 verbose get saving jade-browser-middleware to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\jade-browser-middleware\.cache.json
+1117 http 200 https://registry.npmjs.org/grunt-docker
+1118 silly get cb [ 200,
+1118 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1118 silly get     etag: '"ANX9VOZ612AG0PQNUR88BQM3J"',
+1118 silly get     'content-type': 'application/json',
+1118 silly get     'cache-control': 'max-age=60',
+1118 silly get     'content-length': '14889',
+1118 silly get     'accept-ranges': 'bytes',
+1118 silly get     date: 'Thu, 23 Jul 2015 17:45:56 GMT',
+1118 silly get     via: '1.1 varnish',
+1118 silly get     age: '0',
+1118 silly get     connection: 'keep-alive',
+1118 silly get     'x-served-by': 'cache-lax1423-LAX',
+1118 silly get     'x-cache': 'MISS',
+1118 silly get     'x-cache-hits': '0',
+1118 silly get     'x-timer': 'S1437673556.735100,VS0,VE83',
+1118 silly get     vary: 'Accept' } ]
+1119 verbose get saving grunt-docker to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-docker\.cache.json
+1120 verbose request uri https://registry.npmjs.org/express
+1121 verbose request no auth needed
+1122 info attempt registry request try #1 at 10:45:57 AM
+1123 verbose etag "ANUI3EFPHEF324XD7UAQ6VHK2"
+1124 http request GET https://registry.npmjs.org/express
+1125 verbose request uri https://registry.npmjs.org/express-session
+1126 verbose request no auth needed
+1127 info attempt registry request try #1 at 10:45:57 AM
+1128 verbose etag "B02YWZD382WL0B7VZCFAT85EQ"
+1129 http request GET https://registry.npmjs.org/express-session
+1130 verbose request uri https://registry.npmjs.org/decompress-unzip
+1131 verbose request no auth needed
+1132 info attempt registry request try #1 at 10:45:57 AM
+1133 verbose etag "9Z5BZUA4YZNDOAOS4WAVB12PY"
+1134 http request GET https://registry.npmjs.org/decompress-unzip
+1135 verbose request uri https://registry.npmjs.org/jade
+1136 verbose request no auth needed
+1137 info attempt registry request try #1 at 10:45:57 AM
+1138 verbose etag "6OB3AH54VRWOQGY6A4IF4I11J"
+1139 http request GET https://registry.npmjs.org/jade
+1140 verbose request uri https://registry.npmjs.org/decompress
+1141 verbose request no auth needed
+1142 info attempt registry request try #1 at 10:45:57 AM
+1143 verbose etag "517H0AV4PEOVFIBMG42RRO25Y"
+1144 http request GET https://registry.npmjs.org/decompress
+1145 verbose request uri https://registry.npmjs.org/lodash
+1146 verbose request no auth needed
+1147 info attempt registry request try #1 at 10:45:57 AM
+1148 verbose etag "DPBETPUBC73RQJ6K961FFQGXG"
+1149 http request GET https://registry.npmjs.org/lodash
+1150 verbose request uri https://registry.npmjs.org/express-jwt
+1151 verbose request no auth needed
+1152 info attempt registry request try #1 at 10:45:57 AM
+1153 verbose etag "EJYFM8JXD0XIILQJAH9JNCWA7"
+1154 http request GET https://registry.npmjs.org/express-jwt
+1155 verbose request uri https://registry.npmjs.org/mongoose
+1156 verbose request no auth needed
+1157 info attempt registry request try #1 at 10:45:57 AM
+1158 verbose etag "7RL0RXLQAQMTU0KKQ4V1OCG35"
+1159 http request GET https://registry.npmjs.org/mongoose
+1160 verbose request uri https://registry.npmjs.org/jsonwebtoken
+1161 verbose request no auth needed
+1162 info attempt registry request try #1 at 10:45:57 AM
+1163 verbose etag "C0DNCXIBK418YIJWOUYQVR0CX"
+1164 http request GET https://registry.npmjs.org/jsonwebtoken
+1165 verbose request uri https://registry.npmjs.org/morgan
+1166 verbose request no auth needed
+1167 info attempt registry request try #1 at 10:45:57 AM
+1168 verbose etag "CC7HNQBRSKA1GPGCUI87E0J34"
+1169 http request GET https://registry.npmjs.org/morgan
+1170 verbose request uri https://registry.npmjs.org/multer
+1171 verbose request no auth needed
+1172 info attempt registry request try #1 at 10:45:57 AM
+1173 verbose etag "BV6VC1RBABSD9NJ8M0UYXRDNX"
+1174 http request GET https://registry.npmjs.org/multer
+1175 verbose request uri https://registry.npmjs.org/errorhandler
+1176 verbose request no auth needed
+1177 info attempt registry request try #1 at 10:45:57 AM
+1178 verbose etag "BEFZ0TZIAOMLUJD5T1IKZZRDC"
+1179 http request GET https://registry.npmjs.org/errorhandler
+1180 verbose request uri https://registry.npmjs.org/passport
+1181 verbose request no auth needed
+1182 info attempt registry request try #1 at 10:45:57 AM
+1183 verbose etag "EFNQDBPF0F0ZBN2Q1611VJQRN"
+1184 http request GET https://registry.npmjs.org/passport
+1185 verbose request uri https://registry.npmjs.org/mongoose-validators
+1186 verbose request no auth needed
+1187 info attempt registry request try #1 at 10:45:57 AM
+1188 verbose etag "78YPWCZKV2ERLR7GE930E6WBW"
+1189 http request GET https://registry.npmjs.org/mongoose-validators
+1190 verbose request uri https://registry.npmjs.org/passport-local
+1191 verbose request no auth needed
+1192 info attempt registry request try #1 at 10:45:57 AM
+1193 verbose etag "75NN66H91I7OAZCM7SD72KUSB"
+1194 http request GET https://registry.npmjs.org/passport-local
+1195 verbose request uri https://registry.npmjs.org/prerender-node
+1196 verbose request no auth needed
+1197 info attempt registry request try #1 at 10:45:57 AM
+1198 verbose etag "7ZM29YO82XFZSGLG3YQVCM3WE"
+1199 http request GET https://registry.npmjs.org/prerender-node
+1200 verbose request uri https://registry.npmjs.org/promise
+1201 verbose request no auth needed
+1202 info attempt registry request try #1 at 10:45:57 AM
+1203 verbose etag "DKFU2GQPGC7OPD1J2YJAEZZ6V"
+1204 http request GET https://registry.npmjs.org/promise
+1205 verbose request uri https://registry.npmjs.org/formidable
+1206 verbose request no auth needed
+1207 info attempt registry request try #1 at 10:45:57 AM
+1208 verbose etag "1LENBDLP1D8WSJZ3FRWO5AOAO"
+1209 http request GET https://registry.npmjs.org/formidable
+1210 verbose request uri https://registry.npmjs.org/method-override
+1211 verbose request no auth needed
+1212 info attempt registry request try #1 at 10:45:57 AM
+1213 verbose etag "NIP0D9XKXLGKJDKN8Q3062PO"
+1214 http request GET https://registry.npmjs.org/method-override
+1215 verbose request uri https://registry.npmjs.org/grunt
+1216 verbose request no auth needed
+1217 info attempt registry request try #1 at 10:45:57 AM
+1218 verbose etag "BUPBHZ6PHEWO3Z02IP48U2PF7"
+1219 http request GET https://registry.npmjs.org/grunt
+1220 verbose request uri https://registry.npmjs.org/serve-favicon
+1221 verbose request no auth needed
+1222 info attempt registry request try #1 at 10:45:57 AM
+1223 verbose etag "6MM2QXHYOE3KF41F86QY2ZYPG"
+1224 http request GET https://registry.npmjs.org/serve-favicon
+1225 verbose request uri https://registry.npmjs.org/fs-extra
+1226 verbose request no auth needed
+1227 info attempt registry request try #1 at 10:45:57 AM
+1228 verbose etag "C8ZKFOYGM5QLZNB7UNPJDIQ2E"
+1229 http request GET https://registry.npmjs.org/fs-extra
+1230 verbose request uri https://registry.npmjs.org/winston
+1231 verbose request no auth needed
+1232 info attempt registry request try #1 at 10:45:57 AM
+1233 verbose etag "5P901P8TA9AWQLSFSAN2CQ55H"
+1234 http request GET https://registry.npmjs.org/winston
+1235 verbose request uri https://registry.npmjs.org/gm
+1236 verbose request no auth needed
+1237 info attempt registry request try #1 at 10:45:57 AM
+1238 verbose etag "7BRGM4VFXMDTMGUEOBTFEEHI8"
+1239 http request GET https://registry.npmjs.org/gm
+1240 verbose request uri https://registry.npmjs.org/grunt-asset-injector
+1241 verbose request no auth needed
+1242 info attempt registry request try #1 at 10:45:57 AM
+1243 verbose etag "7TQ3ESNB99Q74J9U5ADQLVOUT"
+1244 http request GET https://registry.npmjs.org/grunt-asset-injector
+1245 verbose request uri https://registry.npmjs.org/grunt-contrib-clean
+1246 verbose request no auth needed
+1247 info attempt registry request try #1 at 10:45:57 AM
+1248 verbose etag "2FBLHFZX5VK8P9YZ36QGSJQXV"
+1249 http request GET https://registry.npmjs.org/grunt-contrib-clean
+1250 verbose request uri https://registry.npmjs.org/grunt-autoprefixer
+1251 verbose request no auth needed
+1252 info attempt registry request try #1 at 10:45:57 AM
+1253 verbose etag "3CH65G45UO9OBIW9865IP0PL8"
+1254 http request GET https://registry.npmjs.org/grunt-autoprefixer
+1255 verbose request uri https://registry.npmjs.org/connect-livereload
+1256 verbose request no auth needed
+1257 info attempt registry request try #1 at 10:45:57 AM
+1258 verbose etag "CCUCMI1DS52UR3VCL0RR4770N"
+1259 http request GET https://registry.npmjs.org/connect-livereload
+1260 verbose request uri https://registry.npmjs.org/grunt-concurrent
+1261 verbose request no auth needed
+1262 info attempt registry request try #1 at 10:45:57 AM
+1263 verbose etag "37RP6RKVNOVQ6PKEM268TTXDQ"
+1264 http request GET https://registry.npmjs.org/grunt-concurrent
+1265 verbose request uri https://registry.npmjs.org/grunt-contrib-copy
+1266 verbose request no auth needed
+1267 info attempt registry request try #1 at 10:45:57 AM
+1268 verbose etag "6AP11BYFAUTO2KJVRSF7YLXW9"
+1269 http request GET https://registry.npmjs.org/grunt-contrib-copy
+1270 verbose request uri https://registry.npmjs.org/grunt-contrib-cssmin
+1271 verbose request no auth needed
+1272 info attempt registry request try #1 at 10:45:57 AM
+1273 verbose etag "PWHXV48EPB3H4VH7K5SDAW8X"
+1274 http request GET https://registry.npmjs.org/grunt-contrib-cssmin
+1275 verbose request uri https://registry.npmjs.org/grunt-contrib-watch
+1276 verbose request no auth needed
+1277 info attempt registry request try #1 at 10:45:57 AM
+1278 verbose etag "AEA1S80NW4CM7V7LACE7FV03W"
+1279 http request GET https://registry.npmjs.org/grunt-contrib-watch
+1280 verbose request uri https://registry.npmjs.org/grunt-contrib-jshint
+1281 verbose request no auth needed
+1282 info attempt registry request try #1 at 10:45:57 AM
+1283 verbose etag "9YSWNQWHPCIME6EXYW003D90N"
+1284 http request GET https://registry.npmjs.org/grunt-contrib-jshint
+1285 verbose request uri https://registry.npmjs.org/grunt-contrib-jade
+1286 verbose request no auth needed
+1287 info attempt registry request try #1 at 10:45:57 AM
+1288 verbose etag "9RTVWH02MZS79NCRLLELVOBB9"
+1289 http request GET https://registry.npmjs.org/grunt-contrib-jade
+1290 verbose request uri https://registry.npmjs.org/grunt-contrib-imagemin
+1291 verbose request no auth needed
+1292 info attempt registry request try #1 at 10:45:57 AM
+1293 verbose etag "4PH5TWS5V9SG5XYKOM6ZS750I"
+1294 http request GET https://registry.npmjs.org/grunt-contrib-imagemin
+1295 verbose request uri https://registry.npmjs.org/grunt-contrib-htmlmin
+1296 verbose request no auth needed
+1297 info attempt registry request try #1 at 10:45:57 AM
+1298 verbose etag "AZ24ANR8WWS6AAAS2RHOGCMZ8"
+1299 http request GET https://registry.npmjs.org/grunt-contrib-htmlmin
+1300 verbose request uri https://registry.npmjs.org/grunt-express-server
+1301 verbose request no auth needed
+1302 info attempt registry request try #1 at 10:45:57 AM
+1303 verbose etag "94689GQH3XLRTBVCT9EHHBJ8Y"
+1304 http request GET https://registry.npmjs.org/grunt-express-server
+1305 verbose request uri https://registry.npmjs.org/grunt-docco
+1306 verbose request no auth needed
+1307 info attempt registry request try #1 at 10:45:57 AM
+1308 verbose etag "3E56ZDDAGVC3Z9RW09NW0JU8"
+1309 http request GET https://registry.npmjs.org/grunt-docco
+1310 verbose request uri https://registry.npmjs.org/grunt-google-cdn
+1311 verbose request no auth needed
+1312 info attempt registry request try #1 at 10:45:57 AM
+1313 verbose etag "98AMV143LFZ81CXMJP6SGCNQT"
+1314 http request GET https://registry.npmjs.org/grunt-google-cdn
+1315 verbose request uri https://registry.npmjs.org/grunt-dom-munger
+1316 verbose request no auth needed
+1317 info attempt registry request try #1 at 10:45:57 AM
+1318 verbose etag "5DM7T68NE2K8K60YN76DXUZ10"
+1319 http request GET https://registry.npmjs.org/grunt-dom-munger
+1320 verbose request uri https://registry.npmjs.org/grunt-env
+1321 verbose request no auth needed
+1322 info attempt registry request try #1 at 10:45:57 AM
+1323 verbose etag "64LYWJEUX02OFEQ42XU2RK9QA"
+1324 http request GET https://registry.npmjs.org/grunt-env
+1325 verbose request uri https://registry.npmjs.org/grunt-karma
+1326 verbose request no auth needed
+1327 info attempt registry request try #1 at 10:45:57 AM
+1328 verbose etag "78HCH87QAQOVE3MXRJATCN0OO"
+1329 http request GET https://registry.npmjs.org/grunt-karma
+1330 verbose request uri https://registry.npmjs.org/grunt-newer
+1331 verbose request no auth needed
+1332 info attempt registry request try #1 at 10:45:57 AM
+1333 verbose etag "DAMRCCGEU43MHUWZ7KUQHH1K0"
+1334 http request GET https://registry.npmjs.org/grunt-newer
+1335 verbose request uri https://registry.npmjs.org/grunt-ng-annotate
+1336 verbose request no auth needed
+1337 info attempt registry request try #1 at 10:45:57 AM
+1338 verbose etag "1K61XI7JXZ6RHS6U5VH1JJ80L"
+1339 http request GET https://registry.npmjs.org/grunt-ng-annotate
+1340 verbose request uri https://registry.npmjs.org/grunt-node-inspector
+1341 verbose request no auth needed
+1342 info attempt registry request try #1 at 10:45:57 AM
+1343 verbose etag "6RNVPHAN2A74F3ZLDTBXKJC82"
+1344 http request GET https://registry.npmjs.org/grunt-node-inspector
+1345 verbose request uri https://registry.npmjs.org/grunt-open
+1346 verbose request no auth needed
+1347 info attempt registry request try #1 at 10:45:57 AM
+1348 verbose etag "BNU65HXCNE4TUUNNC619W8VGR"
+1349 http request GET https://registry.npmjs.org/grunt-open
+1350 verbose request uri https://registry.npmjs.org/grunt-mocha-test
+1351 verbose request no auth needed
+1352 info attempt registry request try #1 at 10:45:57 AM
+1353 verbose etag "AEPWPU9ISKH8EEUEROZVY9FEC"
+1354 http request GET https://registry.npmjs.org/grunt-mocha-test
+1355 verbose request uri https://registry.npmjs.org/grunt-nodemon
+1356 verbose request no auth needed
+1357 info attempt registry request try #1 at 10:45:57 AM
+1358 verbose etag "E66JUHO7JDO59W01BSOLEQLNS"
+1359 http request GET https://registry.npmjs.org/grunt-nodemon
+1360 verbose request uri https://registry.npmjs.org/grunt-rev
+1361 verbose request no auth needed
+1362 info attempt registry request try #1 at 10:45:57 AM
+1363 verbose etag "EEHOQDS1MVIASBK09VRULD810"
+1364 http request GET https://registry.npmjs.org/grunt-rev
+1365 verbose request uri https://registry.npmjs.org/grunt-svgmin
+1366 verbose request no auth needed
+1367 info attempt registry request try #1 at 10:45:57 AM
+1368 verbose etag "80KQF6L7C1HKB1NGIBSJUQ1PM"
+1369 http request GET https://registry.npmjs.org/grunt-svgmin
+1370 verbose request uri https://registry.npmjs.org/grunt-usemin
+1371 verbose request no auth needed
+1372 info attempt registry request try #1 at 10:45:57 AM
+1373 verbose etag "B4W6R4Y1U8BU9WGZVAGJJYQ98"
+1374 http request GET https://registry.npmjs.org/grunt-usemin
+1375 verbose request uri https://registry.npmjs.org/grunt-wiredep
+1376 verbose request no auth needed
+1377 info attempt registry request try #1 at 10:45:57 AM
+1378 verbose etag "EF74FCKTXFTXPVW3K28EU6F6P"
+1379 http request GET https://registry.npmjs.org/grunt-wiredep
+1380 verbose request uri https://registry.npmjs.org/grunt-protractor-runner
+1381 verbose request no auth needed
+1382 info attempt registry request try #1 at 10:45:57 AM
+1383 verbose etag "6UR3K00J92QSFV97JNBUDWNZ1"
+1384 http request GET https://registry.npmjs.org/grunt-protractor-runner
+1385 verbose request uri https://registry.npmjs.org/jit-grunt
+1386 verbose request no auth needed
+1387 info attempt registry request try #1 at 10:45:57 AM
+1388 verbose etag "922UVBQIJDGZXSG4X4DLWGZGR"
+1389 http request GET https://registry.npmjs.org/jit-grunt
+1390 verbose request uri https://registry.npmjs.org/jshint-stylish
+1391 verbose request no auth needed
+1392 info attempt registry request try #1 at 10:45:57 AM
+1393 verbose etag "1KHQGNIJLB3HUS8Q6WECPDC00"
+1394 http request GET https://registry.npmjs.org/jshint-stylish
+1395 verbose request uri https://registry.npmjs.org/karma-coffee-preprocessor
+1396 verbose request no auth needed
+1397 info attempt registry request try #1 at 10:45:57 AM
+1398 verbose etag "310TSBSVHX4T9ISJSWPMVL481"
+1399 http request GET https://registry.npmjs.org/karma-coffee-preprocessor
+1400 verbose request uri https://registry.npmjs.org/karma-chrome-launcher
+1401 verbose request no auth needed
+1402 info attempt registry request try #1 at 10:45:57 AM
+1403 verbose etag "7SBUM18AQ875Q6AWWXQ3ZFH99"
+1404 http request GET https://registry.npmjs.org/karma-chrome-launcher
+1405 verbose request uri https://registry.npmjs.org/karma
+1406 verbose request no auth needed
+1407 info attempt registry request try #1 at 10:45:58 AM
+1408 verbose etag "8SPWSAH11ER44B2GEJ5F44CZ7"
+1409 http request GET https://registry.npmjs.org/karma
+1410 verbose request uri https://registry.npmjs.org/karma-jade-preprocessor
+1411 verbose request no auth needed
+1412 info attempt registry request try #1 at 10:45:58 AM
+1413 verbose etag "6VG2VUOXWCRGN379BQUHTTD5L"
+1414 http request GET https://registry.npmjs.org/karma-jade-preprocessor
+1415 verbose request uri https://registry.npmjs.org/karma-html2js-preprocessor
+1416 verbose request no auth needed
+1417 info attempt registry request try #1 at 10:45:58 AM
+1418 verbose etag "508OO5WL03Y63PNYU0U9BK7X7"
+1419 http request GET https://registry.npmjs.org/karma-html2js-preprocessor
+1420 verbose request uri https://registry.npmjs.org/karma-jasmine
+1421 verbose request no auth needed
+1422 info attempt registry request try #1 at 10:45:58 AM
+1423 verbose etag "VORR8LHWJK4QEZWHEI16MFVJ"
+1424 http request GET https://registry.npmjs.org/karma-jasmine
+1425 verbose request uri https://registry.npmjs.org/karma-ng-html2js-preprocessor
+1426 verbose request no auth needed
+1427 info attempt registry request try #1 at 10:45:58 AM
+1428 verbose etag "DFV7HNNFFL808JVDUY1K82E5C"
+1429 http request GET https://registry.npmjs.org/karma-ng-html2js-preprocessor
+1430 verbose request uri https://registry.npmjs.org/karma-ng-scenario
+1431 verbose request no auth needed
+1432 info attempt registry request try #1 at 10:45:58 AM
+1433 verbose etag "BQOIIG3JX8DCWK38WYE21RZ2R"
+1434 http request GET https://registry.npmjs.org/karma-ng-scenario
+1435 verbose request uri https://registry.npmjs.org/karma-firefox-launcher
+1436 verbose request no auth needed
+1437 info attempt registry request try #1 at 10:45:58 AM
+1438 verbose etag "3LGEO2D034PSY7WQ571KCITBU"
+1439 http request GET https://registry.npmjs.org/karma-firefox-launcher
+1440 verbose request uri https://registry.npmjs.org/karma-ng-jade2js-preprocessor
+1441 verbose request no auth needed
+1442 info attempt registry request try #1 at 10:45:58 AM
+1443 verbose etag "20AZLLXX6LOKRKYVIWFGVJI6Q"
+1444 http request GET https://registry.npmjs.org/karma-ng-jade2js-preprocessor
+1445 verbose request uri https://registry.npmjs.org/karma-phantomjs-launcher
+1446 verbose request no auth needed
+1447 info attempt registry request try #1 at 10:45:58 AM
+1448 verbose etag "8SS6P4R8XMW8A005XSDPMECFM"
+1449 http request GET https://registry.npmjs.org/karma-phantomjs-launcher
+1450 verbose request uri https://registry.npmjs.org/karma-requirejs
+1451 verbose request no auth needed
+1452 info attempt registry request try #1 at 10:45:58 AM
+1453 verbose etag "4196EIJK2MUDYCE5OEEPO38T"
+1454 http request GET https://registry.npmjs.org/karma-requirejs
+1455 verbose request uri https://registry.npmjs.org/karma-script-launcher
+1456 verbose request no auth needed
+1457 info attempt registry request try #1 at 10:45:58 AM
+1458 verbose etag "B7K7G6UQ3EPBF6VMO7AP9CU9H"
+1459 http request GET https://registry.npmjs.org/karma-script-launcher
+1460 verbose request uri https://registry.npmjs.org/body-parser
+1461 verbose request no auth needed
+1462 info attempt registry request try #1 at 10:45:58 AM
+1463 verbose etag "6FCHYAC6NAF1MURHAEN0Q74FO"
+1464 http request GET https://registry.npmjs.org/body-parser
+1465 verbose request uri https://registry.npmjs.org/open
+1466 verbose request no auth needed
+1467 info attempt registry request try #1 at 10:45:58 AM
+1468 verbose etag "2YZQBX1A1E9EQNG5KX4UZRS3B"
+1469 http request GET https://registry.npmjs.org/open
+1470 verbose request uri https://registry.npmjs.org/requirejs
+1471 verbose request no auth needed
+1472 info attempt registry request try #1 at 10:45:58 AM
+1473 verbose etag "ENZYCLLVXA09XRT3C9DQC0L0W"
+1474 http request GET https://registry.npmjs.org/requirejs
+1475 verbose request uri https://registry.npmjs.org/supertest
+1476 verbose request no auth needed
+1477 info attempt registry request try #1 at 10:45:58 AM
+1478 verbose etag "9E240Y2L1IJ2FGMBN1JX7J3O0"
+1479 http request GET https://registry.npmjs.org/supertest
+1480 verbose request uri https://registry.npmjs.org/cookie-parser
+1481 verbose request no auth needed
+1482 info attempt registry request try #1 at 10:45:58 AM
+1483 verbose etag "8KTWLVZYAI3Q0U9WQ3ILKBR8B"
+1484 http request GET https://registry.npmjs.org/cookie-parser
+1485 verbose request uri https://registry.npmjs.org/grunt-angular-templates
+1486 verbose request no auth needed
+1487 info attempt registry request try #1 at 10:45:58 AM
+1488 verbose etag "184H3QL6QXNXWQY6KT3U46RA7"
+1489 http request GET https://registry.npmjs.org/grunt-angular-templates
+1490 http 200 https://registry.npmjs.org/mongoose-text-search
+1491 silly get cb [ 200,
+1491 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1491 silly get     etag: '"H7OYWJ0QGQ988TEFE8N6IVDM"',
+1491 silly get     'content-type': 'application/json',
+1491 silly get     'cache-control': 'max-age=60',
+1491 silly get     'content-length': '12750',
+1491 silly get     'accept-ranges': 'bytes',
+1491 silly get     date: 'Thu, 23 Jul 2015 17:45:56 GMT',
+1491 silly get     via: '1.1 varnish',
+1491 silly get     age: '0',
+1491 silly get     connection: 'keep-alive',
+1491 silly get     'x-served-by': 'cache-lax1431-LAX',
+1491 silly get     'x-cache': 'MISS',
+1491 silly get     'x-cache-hits': '0',
+1491 silly get     'x-timer': 'S1437673556.703832,VS0,VE203',
+1491 silly get     vary: 'Accept' } ]
+1492 verbose get saving mongoose-text-search to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\mongoose-text-search\.cache.json
+1493 verbose request uri https://registry.npmjs.org/time-grunt
+1494 verbose request no auth needed
+1495 info attempt registry request try #1 at 10:45:58 AM
+1496 verbose etag "4S2NVW82QIDS9C54CGMLSVE9S"
+1497 http request GET https://registry.npmjs.org/time-grunt
+1498 verbose request uri https://registry.npmjs.org/composable-middleware
+1499 verbose request no auth needed
+1500 info attempt registry request try #1 at 10:45:58 AM
+1501 verbose etag "4X9R0RAP8K2O62TZP53K1FHQZ"
+1502 http request GET https://registry.npmjs.org/composable-middleware
+1503 verbose request uri https://registry.npmjs.org/should
+1504 verbose request no auth needed
+1505 info attempt registry request try #1 at 10:45:58 AM
+1506 verbose etag "48NI51GPTWVM4PJ4M1T0Y0S2R"
+1507 http request GET https://registry.npmjs.org/should
+1508 verbose request uri https://registry.npmjs.org/compression
+1509 verbose request no auth needed
+1510 info attempt registry request try #1 at 10:45:58 AM
+1511 verbose etag "F21ZT870S205RZ7NRHMCHFLLZ"
+1512 http request GET https://registry.npmjs.org/compression
+1513 verbose request uri https://registry.npmjs.org/passport-google-oauth
+1514 verbose request no auth needed
+1515 info attempt registry request try #1 at 10:45:58 AM
+1516 verbose etag "8ICS6HTVCRGSX6FAHP8Q2ZW2Z"
+1517 http request GET https://registry.npmjs.org/passport-google-oauth
+1518 verbose request uri https://registry.npmjs.org/connect-mongo
+1519 verbose request no auth needed
+1520 info attempt registry request try #1 at 10:45:58 AM
+1521 verbose etag "A27B8GPTVZ4VYVAEWJY6EF3SL"
+1522 http request GET https://registry.npmjs.org/connect-mongo
+1523 verbose request uri https://registry.npmjs.org/grunt-contrib-uglify
+1524 verbose request no auth needed
+1525 info attempt registry request try #1 at 10:45:58 AM
+1526 verbose etag "1ZHGVXAR9ONOJ3Q5LIW6B0GVU"
+1527 http request GET https://registry.npmjs.org/grunt-contrib-uglify
+1528 verbose request uri https://registry.npmjs.org/passport-twitter
+1529 verbose request no auth needed
+1530 info attempt registry request try #1 at 10:45:58 AM
+1531 verbose etag "6OFR66YZRNQSSPSYGFBTKNO41"
+1532 http request GET https://registry.npmjs.org/passport-twitter
+1533 verbose request uri https://registry.npmjs.org/chokidar
+1534 verbose request no auth needed
+1535 info attempt registry request try #1 at 10:45:58 AM
+1536 verbose etag "ESILNY7FI59ZIDM9KQRZACX7F"
+1537 http request GET https://registry.npmjs.org/chokidar
+1538 http 200 https://registry.npmjs.org/fs-finder
+1539 silly get cb [ 200,
+1539 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1539 silly get     etag: '"6KHV1WAVN2T0AV4W59ZD82AMS"',
+1539 silly get     'content-type': 'application/json',
+1539 silly get     'cache-control': 'max-age=60',
+1539 silly get     'content-length': '24947',
+1539 silly get     'accept-ranges': 'bytes',
+1539 silly get     date: 'Thu, 23 Jul 2015 17:45:57 GMT',
+1539 silly get     via: '1.1 varnish',
+1539 silly get     age: '0',
+1539 silly get     connection: 'keep-alive',
+1539 silly get     'x-served-by': 'cache-lax1435-LAX',
+1539 silly get     'x-cache': 'MISS',
+1539 silly get     'x-cache-hits': '0',
+1539 silly get     'x-timer': 'S1437673556.707002,VS0,VE372',
+1539 silly get     vary: 'Accept' } ]
+1540 verbose get saving fs-finder to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\fs-finder\.cache.json
+1541 verbose request uri https://registry.npmjs.org/passport-facebook
+1542 verbose request no auth needed
+1543 info attempt registry request try #1 at 10:45:58 AM
+1544 verbose etag "D0RPTA2OQDYF2NXDK9C8DRP10"
+1545 http request GET https://registry.npmjs.org/passport-facebook
+1546 verbose request uri https://registry.npmjs.org/grunt-contrib-stylus
+1547 verbose request no auth needed
+1548 info attempt registry request try #1 at 10:45:58 AM
+1549 verbose etag "AX9P1NHQ28UJU015E0D9BX4DJ"
+1550 http request GET https://registry.npmjs.org/grunt-contrib-stylus
+1551 silly addNameRange number 2 { name: 'xml-to-json', range: '>=0.1.1 <0.2.0', hasData: true }
+1552 silly addNameRange versions [ 'xml-to-json', [ '0.0.0', '0.1.0', '0.1.1' ] ]
+1553 verbose addNamed xml-to-json@0.1.1
+1554 silly addNamed semver.valid 0.1.1
+1555 silly addNamed semver.validRange 0.1.1
+1556 silly addNameRange number 2 { name: 'jade-browser-middleware',
+1556 silly addNameRange   range: '>=0.3.3 <0.4.0',
+1556 silly addNameRange   hasData: true }
+1557 silly addNameRange versions [ 'jade-browser-middleware',
+1557 silly addNameRange   [ '0.1.0',
+1557 silly addNameRange     '0.1.1',
+1557 silly addNameRange     '0.2.0',
+1557 silly addNameRange     '0.2.1',
+1557 silly addNameRange     '0.2.2',
+1557 silly addNameRange     '0.2.3',
+1557 silly addNameRange     '0.3.0',
+1557 silly addNameRange     '0.3.1',
+1557 silly addNameRange     '0.3.3' ] ]
+1558 verbose addNamed jade-browser-middleware@0.3.3
+1559 silly addNamed semver.valid 0.3.3
+1560 silly addNamed semver.validRange 0.3.3
+1561 silly mapToRegistry name xml-to-json
+1562 silly mapToRegistry using default registry
+1563 silly mapToRegistry registry https://registry.npmjs.org/
+1564 silly mapToRegistry uri https://registry.npmjs.org/xml-to-json
+1565 verbose addRemoteTarball https://registry.npmjs.org/xml-to-json/-/xml-to-json-0.1.1.tgz not in flight; adding
+1566 verbose addRemoteTarball [ 'https://registry.npmjs.org/xml-to-json/-/xml-to-json-0.1.1.tgz',
+1566 verbose addRemoteTarball   '1f01b3cc02c5c33a3d057342218bb91d961b622e' ]
+1567 silly mapToRegistry name jade-browser-middleware
+1568 silly mapToRegistry using default registry
+1569 silly mapToRegistry registry https://registry.npmjs.org/
+1570 silly mapToRegistry uri https://registry.npmjs.org/jade-browser-middleware
+1571 verbose addRemoteTarball https://registry.npmjs.org/jade-browser-middleware/-/jade-browser-middleware-0.3.3.tgz not in flight; adding
+1572 verbose addRemoteTarball [ 'https://registry.npmjs.org/jade-browser-middleware/-/jade-browser-middleware-0.3.3.tgz',
+1572 verbose addRemoteTarball   '0594c1ad03d1653b79d080ca330177e5e20a7072' ]
+1573 silly mapToRegistry name grunt-docker
+1574 silly mapToRegistry using default registry
+1575 silly mapToRegistry registry https://registry.npmjs.org/
+1576 silly mapToRegistry uri https://registry.npmjs.org/grunt-docker
+1577 verbose addRemoteTarball https://registry.npmjs.org/grunt-docker/-/grunt-docker-0.0.10.tgz not in flight; adding
+1578 verbose addRemoteTarball [ 'https://registry.npmjs.org/grunt-docker/-/grunt-docker-0.0.10.tgz',
+1578 verbose addRemoteTarball   '5ea38b08601e77a76ad756f9b0dd86eed68f4fe3' ]
+1579 http 304 https://registry.npmjs.org/express
+1580 silly get cb [ 304,
+1580 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1580 silly get     via: '1.1 varnish',
+1580 silly get     'cache-control': 'max-age=60',
+1580 silly get     etag: '"ANUI3EFPHEF324XD7UAQ6VHK2"',
+1580 silly get     age: '25',
+1580 silly get     connection: 'keep-alive',
+1580 silly get     'x-served-by': 'cache-lax1422-LAX',
+1580 silly get     'x-cache': 'HIT',
+1580 silly get     'x-cache-hits': '91',
+1580 silly get     'x-timer': 'S1437673558.153727,VS0,VE0',
+1580 silly get     vary: 'Accept' } ]
+1581 verbose etag https://registry.npmjs.org/express from cache
+1582 verbose get saving express to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\express\.cache.json
+1583 http 304 https://registry.npmjs.org/express-session
+1584 silly get cb [ 304,
+1584 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1584 silly get     via: '1.1 varnish',
+1584 silly get     'cache-control': 'max-age=60',
+1584 silly get     etag: '"B02YWZD382WL0B7VZCFAT85EQ"',
+1584 silly get     age: '24',
+1584 silly get     connection: 'keep-alive',
+1584 silly get     'x-served-by': 'cache-lax1435-LAX',
+1584 silly get     'x-cache': 'HIT',
+1584 silly get     'x-cache-hits': '1',
+1584 silly get     'x-timer': 'S1437673558.161443,VS0,VE0',
+1584 silly get     vary: 'Accept' } ]
+1585 verbose etag https://registry.npmjs.org/express-session from cache
+1586 verbose get saving express-session to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\express-session\.cache.json
+1587 http 304 https://registry.npmjs.org/lodash
+1588 silly get cb [ 304,
+1588 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1588 silly get     via: '1.1 varnish',
+1588 silly get     'cache-control': 'max-age=60',
+1588 silly get     etag: '"DPBETPUBC73RQJ6K961FFQGXG"',
+1588 silly get     age: '32',
+1588 silly get     connection: 'keep-alive',
+1588 silly get     'x-served-by': 'cache-lax1435-LAX',
+1588 silly get     'x-cache': 'HIT',
+1588 silly get     'x-cache-hits': '5',
+1588 silly get     'x-timer': 'S1437673558.299733,VS0,VE0',
+1588 silly get     vary: 'Accept' } ]
+1589 verbose etag https://registry.npmjs.org/lodash from cache
+1590 verbose get saving lodash to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\lodash\.cache.json
+1591 http 304 https://registry.npmjs.org/morgan
+1592 silly get cb [ 304,
+1592 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1592 silly get     via: '1.1 varnish',
+1592 silly get     'cache-control': 'max-age=60',
+1592 silly get     etag: '"CC7HNQBRSKA1GPGCUI87E0J34"',
+1592 silly get     age: '25',
+1592 silly get     connection: 'keep-alive',
+1592 silly get     'x-served-by': 'cache-lax1420-LAX',
+1592 silly get     'x-cache': 'HIT',
+1592 silly get     'x-cache-hits': '2',
+1592 silly get     'x-timer': 'S1437673558.300162,VS0,VE0',
+1592 silly get     vary: 'Accept' } ]
+1593 verbose etag https://registry.npmjs.org/morgan from cache
+1594 verbose get saving morgan to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\morgan\.cache.json
+1595 http 200 https://registry.npmjs.org/jsonwebtoken
+1596 silly get cb [ 200,
+1596 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1596 silly get     etag: '"7CJHSSIBT5EQTL6TU5MEWVTFE"',
+1596 silly get     'content-type': 'application/json',
+1596 silly get     'cache-control': 'max-age=60',
+1596 silly get     'content-length': '44562',
+1596 silly get     'accept-ranges': 'bytes',
+1596 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1596 silly get     via: '1.1 varnish',
+1596 silly get     age: '46',
+1596 silly get     connection: 'keep-alive',
+1596 silly get     'x-served-by': 'cache-lax1431-LAX',
+1596 silly get     'x-cache': 'HIT',
+1596 silly get     'x-cache-hits': '1',
+1596 silly get     'x-timer': 'S1437673558.301208,VS0,VE0',
+1596 silly get     vary: 'Accept' } ]
+1597 verbose get saving jsonwebtoken to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\jsonwebtoken\.cache.json
+1598 http 304 https://registry.npmjs.org/errorhandler
+1599 silly get cb [ 304,
+1599 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1599 silly get     via: '1.1 varnish',
+1599 silly get     'cache-control': 'max-age=60',
+1599 silly get     etag: '"BEFZ0TZIAOMLUJD5T1IKZZRDC"',
+1599 silly get     age: '24',
+1599 silly get     connection: 'keep-alive',
+1599 silly get     'x-served-by': 'cache-lax1421-LAX',
+1599 silly get     'x-cache': 'HIT',
+1599 silly get     'x-cache-hits': '1',
+1599 silly get     'x-timer': 'S1437673558.306530,VS0,VE0',
+1599 silly get     vary: 'Accept' } ]
+1600 verbose etag https://registry.npmjs.org/errorhandler from cache
+1601 verbose get saving errorhandler to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\errorhandler\.cache.json
+1602 http 304 https://registry.npmjs.org/method-override
+1603 silly get cb [ 304,
+1603 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1603 silly get     via: '1.1 varnish',
+1603 silly get     'cache-control': 'max-age=60',
+1603 silly get     etag: '"NIP0D9XKXLGKJDKN8Q3062PO"',
+1603 silly get     age: '38',
+1603 silly get     connection: 'keep-alive',
+1603 silly get     'x-served-by': 'cache-lax1421-LAX',
+1603 silly get     'x-cache': 'HIT',
+1603 silly get     'x-cache-hits': '1',
+1603 silly get     'x-timer': 'S1437673558.306623,VS0,VE0',
+1603 silly get     vary: 'Accept' } ]
+1604 verbose etag https://registry.npmjs.org/method-override from cache
+1605 verbose get saving method-override to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\method-override\.cache.json
+1606 http 200 https://registry.npmjs.org/formidable
+1607 silly get cb [ 200,
+1607 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1607 silly get     etag: '"6LZC5QBYRPJ5UNAT1DHE4F1IN"',
+1607 silly get     'content-type': 'application/json',
+1607 silly get     'cache-control': 'max-age=60',
+1607 silly get     'content-length': '38972',
+1607 silly get     'accept-ranges': 'bytes',
+1607 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1607 silly get     via: '1.1 varnish',
+1607 silly get     age: '32',
+1607 silly get     connection: 'keep-alive',
+1607 silly get     'x-served-by': 'cache-lax1424-LAX',
+1607 silly get     'x-cache': 'HIT',
+1607 silly get     'x-cache-hits': '2',
+1607 silly get     'x-timer': 'S1437673558.301232,VS0,VE0',
+1607 silly get     vary: 'Accept' } ]
+1608 verbose get saving formidable to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\formidable\.cache.json
+1609 http 200 https://registry.npmjs.org/serve-favicon
+1610 silly get cb [ 200,
+1610 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1610 silly get     etag: '"5TG3NAWC5FTNYEAABS1T0U5R8"',
+1610 silly get     'content-type': 'application/json',
+1610 silly get     'cache-control': 'max-age=60',
+1610 silly get     'content-length': '23845',
+1610 silly get     'accept-ranges': 'bytes',
+1610 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1610 silly get     via: '1.1 varnish',
+1610 silly get     age: '25',
+1610 silly get     connection: 'keep-alive',
+1610 silly get     'x-served-by': 'cache-lax1424-LAX',
+1610 silly get     'x-cache': 'HIT',
+1610 silly get     'x-cache-hits': '2',
+1610 silly get     'x-timer': 'S1437673558.301252,VS0,VE0',
+1610 silly get     vary: 'Accept' } ]
+1611 verbose get saving serve-favicon to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\serve-favicon\.cache.json
+1612 http 304 https://registry.npmjs.org/passport
+1613 silly get cb [ 304,
+1613 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1613 silly get     via: '1.1 varnish',
+1613 silly get     'cache-control': 'max-age=60',
+1613 silly get     etag: '"EFNQDBPF0F0ZBN2Q1611VJQRN"',
+1613 silly get     age: '26',
+1613 silly get     connection: 'keep-alive',
+1613 silly get     'x-served-by': 'cache-lax1433-LAX',
+1613 silly get     'x-cache': 'HIT',
+1613 silly get     'x-cache-hits': '1',
+1613 silly get     'x-timer': 'S1437673558.302467,VS0,VE0',
+1613 silly get     vary: 'Accept' } ]
+1614 verbose etag https://registry.npmjs.org/passport from cache
+1615 verbose get saving passport to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\passport\.cache.json
+1616 http 200 https://registry.npmjs.org/express-jwt
+1617 silly get cb [ 200,
+1617 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1617 silly get     etag: '"5N1XTRCA4D8ILKQA27JBLVR29"',
+1617 silly get     'content-type': 'application/json',
+1617 silly get     'cache-control': 'max-age=60',
+1617 silly get     'content-length': '42254',
+1617 silly get     'accept-ranges': 'bytes',
+1617 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1617 silly get     via: '1.1 varnish',
+1617 silly get     age: '45',
+1617 silly get     connection: 'keep-alive',
+1617 silly get     'x-served-by': 'cache-lax1430-LAX',
+1617 silly get     'x-cache': 'HIT',
+1617 silly get     'x-cache-hits': '1',
+1617 silly get     'x-timer': 'S1437673558.300893,VS0,VE2',
+1617 silly get     vary: 'Accept' } ]
+1618 verbose get saving express-jwt to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\express-jwt\.cache.json
+1619 http 304 https://registry.npmjs.org/mongoose
+1620 silly get cb [ 304,
+1620 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1620 silly get     via: '1.1 varnish',
+1620 silly get     'cache-control': 'max-age=60',
+1620 silly get     etag: '"7RL0RXLQAQMTU0KKQ4V1OCG35"',
+1620 silly get     age: '0',
+1620 silly get     connection: 'keep-alive',
+1620 silly get     'x-served-by': 'cache-lax1432-LAX',
+1620 silly get     'x-cache': 'HIT',
+1620 silly get     'x-cache-hits': '1',
+1620 silly get     'x-timer': 'S1437673558.300029,VS0,VE2',
+1620 silly get     vary: 'Accept' } ]
+1621 verbose etag https://registry.npmjs.org/mongoose from cache
+1622 verbose get saving mongoose to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\mongoose\.cache.json
+1623 http 304 https://registry.npmjs.org/passport-local
+1624 silly get cb [ 304,
+1624 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1624 silly get     via: '1.1 varnish',
+1624 silly get     'cache-control': 'max-age=60',
+1624 silly get     etag: '"75NN66H91I7OAZCM7SD72KUSB"',
+1624 silly get     age: '0',
+1624 silly get     connection: 'keep-alive',
+1624 silly get     'x-served-by': 'cache-lax1423-LAX',
+1624 silly get     'x-cache': 'HIT',
+1624 silly get     'x-cache-hits': '1',
+1624 silly get     'x-timer': 'S1437673558.305658,VS0,VE0',
+1624 silly get     vary: 'Accept' } ]
+1625 verbose etag https://registry.npmjs.org/passport-local from cache
+1626 verbose get saving passport-local to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\passport-local\.cache.json
+1627 http 304 https://registry.npmjs.org/multer
+1628 silly get cb [ 304,
+1628 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1628 silly get     via: '1.1 varnish',
+1628 silly get     'cache-control': 'max-age=60',
+1628 silly get     etag: '"BV6VC1RBABSD9NJ8M0UYXRDNX"',
+1628 silly get     age: '0',
+1628 silly get     connection: 'keep-alive',
+1628 silly get     'x-served-by': 'cache-lax1433-LAX',
+1628 silly get     'x-cache': 'HIT',
+1628 silly get     'x-cache-hits': '1',
+1628 silly get     'x-timer': 'S1437673558.302424,VS0,VE43',
+1628 silly get     vary: 'Accept' } ]
+1629 verbose etag https://registry.npmjs.org/multer from cache
+1630 verbose get saving multer to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\multer\.cache.json
+1631 http 304 https://registry.npmjs.org/decompress
+1632 silly get cb [ 304,
+1632 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1632 silly get     via: '1.1 varnish',
+1632 silly get     'cache-control': 'max-age=60',
+1632 silly get     etag: '"517H0AV4PEOVFIBMG42RRO25Y"',
+1632 silly get     age: '0',
+1632 silly get     connection: 'keep-alive',
+1632 silly get     'x-served-by': 'cache-lax1428-LAX',
+1632 silly get     'x-cache': 'HIT',
+1632 silly get     'x-cache-hits': '1',
+1632 silly get     'x-timer': 'S1437673558.301062,VS0,VE45',
+1632 silly get     vary: 'Accept' } ]
+1633 verbose etag https://registry.npmjs.org/decompress from cache
+1634 verbose get saving decompress to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\decompress\.cache.json
+1635 http 304 https://registry.npmjs.org/grunt-contrib-htmlmin
+1636 silly get cb [ 304,
+1636 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1636 silly get     via: '1.1 varnish',
+1636 silly get     'cache-control': 'max-age=60',
+1636 silly get     etag: '"AZ24ANR8WWS6AAAS2RHOGCMZ8"',
+1636 silly get     age: '0',
+1636 silly get     connection: 'keep-alive',
+1636 silly get     'x-served-by': 'cache-lax1428-LAX',
+1636 silly get     'x-cache': 'HIT',
+1636 silly get     'x-cache-hits': '1',
+1636 silly get     'x-timer': 'S1437673558.305686,VS0,VE43',
+1636 silly get     vary: 'Accept' } ]
+1637 verbose etag https://registry.npmjs.org/grunt-contrib-htmlmin from cache
+1638 verbose get saving grunt-contrib-htmlmin to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-htmlmin\.cache.json
+1639 http 304 https://registry.npmjs.org/mongoose-validators
+1640 silly get cb [ 304,
+1640 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1640 silly get     via: '1.1 varnish',
+1640 silly get     'cache-control': 'max-age=60',
+1640 silly get     etag: '"78YPWCZKV2ERLR7GE930E6WBW"',
+1640 silly get     age: '0',
+1640 silly get     connection: 'keep-alive',
+1640 silly get     'x-served-by': 'cache-lax1432-LAX',
+1640 silly get     'x-cache': 'MISS',
+1640 silly get     'x-cache-hits': '0',
+1640 silly get     'x-timer': 'S1437673558.300649,VS0,VE54',
+1640 silly get     vary: 'Accept' } ]
+1641 verbose etag https://registry.npmjs.org/mongoose-validators from cache
+1642 verbose get saving mongoose-validators to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\mongoose-validators\.cache.json
+1643 http 304 https://registry.npmjs.org/decompress-unzip
+1644 silly get cb [ 304,
+1644 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1644 silly get     via: '1.1 varnish',
+1644 silly get     'cache-control': 'max-age=60',
+1644 silly get     etag: '"9Z5BZUA4YZNDOAOS4WAVB12PY"',
+1644 silly get     age: '0',
+1644 silly get     connection: 'keep-alive',
+1644 silly get     'x-served-by': 'cache-lax1425-LAX',
+1644 silly get     'x-cache': 'HIT',
+1644 silly get     'x-cache-hits': '1',
+1644 silly get     'x-timer': 'S1437673558.294711,VS0,VE84',
+1644 silly get     vary: 'Accept' } ]
+1645 verbose etag https://registry.npmjs.org/decompress-unzip from cache
+1646 verbose get saving decompress-unzip to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\decompress-unzip\.cache.json
+1647 http 304 https://registry.npmjs.org/connect-livereload
+1648 silly get cb [ 304,
+1648 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1648 silly get     via: '1.1 varnish',
+1648 silly get     'cache-control': 'max-age=60',
+1648 silly get     etag: '"CCUCMI1DS52UR3VCL0RR4770N"',
+1648 silly get     age: '11',
+1648 silly get     connection: 'keep-alive',
+1648 silly get     'x-served-by': 'cache-lax1433-LAX',
+1648 silly get     'x-cache': 'HIT',
+1648 silly get     'x-cache-hits': '2',
+1648 silly get     'x-timer': 'S1437673558.385296,VS0,VE0',
+1648 silly get     vary: 'Accept' } ]
+1649 verbose etag https://registry.npmjs.org/connect-livereload from cache
+1650 verbose get saving connect-livereload to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\connect-livereload\.cache.json
+1651 http 304 https://registry.npmjs.org/promise
+1652 silly get cb [ 304,
+1652 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1652 silly get     via: '1.1 varnish',
+1652 silly get     'cache-control': 'max-age=60',
+1652 silly get     etag: '"DKFU2GQPGC7OPD1J2YJAEZZ6V"',
+1652 silly get     age: '17',
+1652 silly get     connection: 'keep-alive',
+1652 silly get     'x-served-by': 'cache-lax1423-LAX',
+1652 silly get     'x-cache': 'HIT',
+1652 silly get     'x-cache-hits': '1',
+1652 silly get     'x-timer': 'S1437673558.383714,VS0,VE0',
+1652 silly get     vary: 'Accept' } ]
+1653 verbose etag https://registry.npmjs.org/promise from cache
+1654 verbose get saving promise to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\promise\.cache.json
+1655 http 304 https://registry.npmjs.org/grunt-concurrent
+1656 silly get cb [ 304,
+1656 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1656 silly get     via: '1.1 varnish',
+1656 silly get     'cache-control': 'max-age=60',
+1656 silly get     etag: '"37RP6RKVNOVQ6PKEM268TTXDQ"',
+1656 silly get     age: '17',
+1656 silly get     connection: 'keep-alive',
+1656 silly get     'x-served-by': 'cache-lax1431-LAX',
+1656 silly get     'x-cache': 'HIT',
+1656 silly get     'x-cache-hits': '1',
+1656 silly get     'x-timer': 'S1437673558.388623,VS0,VE0',
+1656 silly get     vary: 'Accept' } ]
+1657 verbose etag https://registry.npmjs.org/grunt-concurrent from cache
+1658 verbose get saving grunt-concurrent to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-concurrent\.cache.json
+1659 http 304 https://registry.npmjs.org/grunt-contrib-imagemin
+1660 silly get cb [ 304,
+1660 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1660 silly get     via: '1.1 varnish',
+1660 silly get     'cache-control': 'max-age=60',
+1660 silly get     etag: '"4PH5TWS5V9SG5XYKOM6ZS750I"',
+1660 silly get     age: '0',
+1660 silly get     connection: 'keep-alive',
+1660 silly get     'x-served-by': 'cache-lax1423-LAX',
+1660 silly get     'x-cache': 'HIT',
+1660 silly get     'x-cache-hits': '1',
+1660 silly get     'x-timer': 'S1437673558.305592,VS0,VE84',
+1660 silly get     vary: 'Accept' } ]
+1661 verbose etag https://registry.npmjs.org/grunt-contrib-imagemin from cache
+1662 verbose get saving grunt-contrib-imagemin to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-imagemin\.cache.json
+1663 http 304 https://registry.npmjs.org/jade
+1664 silly get cb [ 304,
+1664 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1664 silly get     via: '1.1 varnish',
+1664 silly get     'cache-control': 'max-age=60',
+1664 silly get     etag: '"6OB3AH54VRWOQGY6A4IF4I11J"',
+1664 silly get     age: '0',
+1664 silly get     connection: 'keep-alive',
+1664 silly get     'x-served-by': 'cache-lax1423-LAX',
+1664 silly get     'x-cache': 'HIT',
+1664 silly get     'x-cache-hits': '1',
+1664 silly get     'x-timer': 'S1437673558.299687,VS0,VE118',
+1664 silly get     vary: 'Accept' } ]
+1665 verbose etag https://registry.npmjs.org/jade from cache
+1666 verbose get saving jade to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\jade\.cache.json
+1667 http 304 https://registry.npmjs.org/grunt-mocha-test
+1668 silly get cb [ 304,
+1668 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1668 silly get     via: '1.1 varnish',
+1668 silly get     'cache-control': 'max-age=60',
+1668 silly get     etag: '"AEPWPU9ISKH8EEUEROZVY9FEC"',
+1668 silly get     age: '10',
+1668 silly get     connection: 'keep-alive',
+1668 silly get     'x-served-by': 'cache-lax1422-LAX',
+1668 silly get     'x-cache': 'HIT',
+1668 silly get     'x-cache-hits': '1',
+1668 silly get     'x-timer': 'S1437673558.426859,VS0,VE0',
+1668 silly get     vary: 'Accept' } ]
+1669 verbose etag https://registry.npmjs.org/grunt-mocha-test from cache
+1670 verbose get saving grunt-mocha-test to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-mocha-test\.cache.json
+1671 silly mapToRegistry name mongoose-text-search
+1672 silly mapToRegistry using default registry
+1673 silly mapToRegistry registry https://registry.npmjs.org/
+1674 silly mapToRegistry uri https://registry.npmjs.org/mongoose-text-search
+1675 verbose addRemoteTarball https://registry.npmjs.org/mongoose-text-search/-/mongoose-text-search-0.0.2.tgz not in flight; adding
+1676 verbose addRemoteTarball [ 'https://registry.npmjs.org/mongoose-text-search/-/mongoose-text-search-0.0.2.tgz',
+1676 verbose addRemoteTarball   '0bd54954584a011d25655de7a70674ad50bce19e' ]
+1677 silly addNameRange number 2 { name: 'fs-finder', range: '>=1.8.0 <2.0.0', hasData: true }
+1678 silly addNameRange versions [ 'fs-finder',
+1678 silly addNameRange   [ '1.0.0',
+1678 silly addNameRange     '1.0.1',
+1678 silly addNameRange     '1.1.0',
+1678 silly addNameRange     '1.2.0',
+1678 silly addNameRange     '1.3.0',
+1678 silly addNameRange     '1.4.0',
+1678 silly addNameRange     '1.4.1',
+1678 silly addNameRange     '1.4.2',
+1678 silly addNameRange     '1.4.3',
+1678 silly addNameRange     '1.5.0',
+1678 silly addNameRange     '1.5.1',
+1678 silly addNameRange     '1.6.0',
+1678 silly addNameRange     '1.7.0',
+1678 silly addNameRange     '1.7.2',
+1678 silly addNameRange     '1.7.3',
+1678 silly addNameRange     '1.7.4',
+1678 silly addNameRange     '1.8.0',
+1678 silly addNameRange     '1.8.1' ] ]
+1679 verbose addNamed fs-finder@1.8.1
+1680 silly addNamed semver.valid 1.8.1
+1681 silly addNamed semver.validRange 1.8.1
+1682 http 304 https://registry.npmjs.org/prerender-node
+1683 silly get cb [ 304,
+1683 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1683 silly get     via: '1.1 varnish',
+1683 silly get     'cache-control': 'max-age=60',
+1683 silly get     etag: '"7ZM29YO82XFZSGLG3YQVCM3WE"',
+1683 silly get     age: '0',
+1683 silly get     connection: 'keep-alive',
+1683 silly get     'x-served-by': 'cache-lax1426-LAX',
+1683 silly get     'x-cache': 'MISS',
+1683 silly get     'x-cache-hits': '0',
+1683 silly get     'x-timer': 'S1437673558.375562,VS0,VE86',
+1683 silly get     vary: 'Accept' } ]
+1684 verbose etag https://registry.npmjs.org/prerender-node from cache
+1685 verbose get saving prerender-node to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\prerender-node\.cache.json
+1686 http 200 https://registry.npmjs.org/grunt-dom-munger
+1687 silly get cb [ 200,
+1687 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1687 silly get     etag: '"TJRSRQ4UAWJ8DYG38BIJD0WO"',
+1687 silly get     'content-type': 'application/json',
+1687 silly get     'cache-control': 'max-age=60',
+1687 silly get     'content-length': '25732',
+1687 silly get     'accept-ranges': 'bytes',
+1687 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1687 silly get     via: '1.1 varnish',
+1687 silly get     age: '0',
+1687 silly get     connection: 'keep-alive',
+1687 silly get     'x-served-by': 'cache-lax1427-LAX',
+1687 silly get     'x-cache': 'HIT',
+1687 silly get     'x-cache-hits': '1',
+1687 silly get     'x-timer': 'S1437673558.422756,VS0,VE47',
+1687 silly get     vary: 'Accept' } ]
+1688 verbose get saving grunt-dom-munger to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-dom-munger\.cache.json
+1689 http 304 https://registry.npmjs.org/grunt-node-inspector
+1690 silly get cb [ 304,
+1690 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1690 silly get     via: '1.1 varnish',
+1690 silly get     'cache-control': 'max-age=60',
+1690 silly get     etag: '"6RNVPHAN2A74F3ZLDTBXKJC82"',
+1690 silly get     age: '0',
+1690 silly get     connection: 'keep-alive',
+1690 silly get     'x-served-by': 'cache-lax1421-LAX',
+1690 silly get     'x-cache': 'HIT',
+1690 silly get     'x-cache-hits': '1',
+1690 silly get     'x-timer': 'S1437673558.430983,VS0,VE48',
+1690 silly get     vary: 'Accept' } ]
+1691 verbose etag https://registry.npmjs.org/grunt-node-inspector from cache
+1692 verbose get saving grunt-node-inspector to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-node-inspector\.cache.json
+1693 http 200 https://registry.npmjs.org/grunt-nodemon
+1694 silly get cb [ 200,
+1694 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1694 silly get     etag: '"5QWCPQRI0GAT52UGY3239HYSX"',
+1694 silly get     'content-type': 'application/json',
+1694 silly get     'cache-control': 'max-age=60',
+1694 silly get     'content-length': '28214',
+1694 silly get     'accept-ranges': 'bytes',
+1694 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1694 silly get     via: '1.1 varnish',
+1694 silly get     age: '0',
+1694 silly get     connection: 'keep-alive',
+1694 silly get     'x-served-by': 'cache-lax1423-LAX',
+1694 silly get     'x-cache': 'HIT',
+1694 silly get     'x-cache-hits': '1',
+1694 silly get     'x-timer': 'S1437673558.424720,VS0,VE47',
+1694 silly get     vary: 'Accept' } ]
+1695 verbose get saving grunt-nodemon to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-nodemon\.cache.json
+1696 http 200 https://registry.npmjs.org/grunt-rev
+1697 silly get cb [ 200,
+1697 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1697 silly get     etag: '"AXZEYQ37FLQ0ISPTKPRH673TZ"',
+1697 silly get     'content-type': 'application/json',
+1697 silly get     'cache-control': 'max-age=60',
+1697 silly get     'content-length': '8094',
+1697 silly get     'accept-ranges': 'bytes',
+1697 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1697 silly get     via: '1.1 varnish',
+1697 silly get     age: '0',
+1697 silly get     connection: 'keep-alive',
+1697 silly get     'x-served-by': 'cache-lax1422-LAX',
+1697 silly get     'x-cache': 'HIT',
+1697 silly get     'x-cache-hits': '1',
+1697 silly get     'x-timer': 'S1437673558.426856,VS0,VE49',
+1697 silly get     vary: 'Accept' } ]
+1698 verbose get saving grunt-rev to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-rev\.cache.json
+1699 http 304 https://registry.npmjs.org/grunt-docco
+1700 silly get cb [ 304,
+1700 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1700 silly get     via: '1.1 varnish',
+1700 silly get     'cache-control': 'max-age=60',
+1700 silly get     etag: '"3E56ZDDAGVC3Z9RW09NW0JU8"',
+1700 silly get     age: '0',
+1700 silly get     connection: 'keep-alive',
+1700 silly get     'x-served-by': 'cache-lax1429-LAX',
+1700 silly get     'x-cache': 'MISS',
+1700 silly get     'x-cache-hits': '0',
+1700 silly get     'x-timer': 'S1437673558.419933,VS0,VE60',
+1700 silly get     vary: 'Accept' } ]
+1701 verbose etag https://registry.npmjs.org/grunt-docco from cache
+1702 verbose get saving grunt-docco to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-docco\.cache.json
+1703 http 304 https://registry.npmjs.org/cookie-parser
+1704 silly get cb [ 304,
+1704 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1704 silly get     via: '1.1 varnish',
+1704 silly get     'cache-control': 'max-age=60',
+1704 silly get     etag: '"8KTWLVZYAI3Q0U9WQ3ILKBR8B"',
+1704 silly get     age: '24',
+1704 silly get     connection: 'keep-alive',
+1704 silly get     'x-served-by': 'cache-lax1421-LAX',
+1704 silly get     'x-cache': 'HIT',
+1704 silly get     'x-cache-hits': '3',
+1704 silly get     'x-timer': 'S1437673558.486680,VS0,VE0',
+1704 silly get     vary: 'Accept' } ]
+1705 verbose etag https://registry.npmjs.org/cookie-parser from cache
+1706 verbose get saving cookie-parser to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\cookie-parser\.cache.json
+1707 http 200 https://registry.npmjs.org/karma-chrome-launcher
+1708 silly get cb [ 200,
+1708 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1708 silly get     etag: '"D7KLWQEIJ3RZAB07G5KCU0HIS"',
+1708 silly get     'content-type': 'application/json',
+1708 silly get     'cache-control': 'max-age=60',
+1708 silly get     'content-length': '30197',
+1708 silly get     'accept-ranges': 'bytes',
+1708 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1708 silly get     via: '1.1 varnish',
+1708 silly get     age: '17',
+1708 silly get     connection: 'keep-alive',
+1708 silly get     'x-served-by': 'cache-lax1421-LAX',
+1708 silly get     'x-cache': 'HIT',
+1708 silly get     'x-cache-hits': '1',
+1708 silly get     'x-timer': 'S1437673558.486376,VS0,VE0',
+1708 silly get     vary: 'Accept' } ]
+1709 verbose get saving karma-chrome-launcher to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-chrome-launcher\.cache.json
+1710 http 200 https://registry.npmjs.org/karma-phantomjs-launcher
+1711 silly get cb [ 200,
+1711 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1711 silly get     etag: '"6QEMJXIEFKDNUO8OR7TJM268U"',
+1711 silly get     'content-type': 'application/json',
+1711 silly get     'cache-control': 'max-age=60',
+1711 silly get     'content-length': '18660',
+1711 silly get     'accept-ranges': 'bytes',
+1711 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1711 silly get     via: '1.1 varnish',
+1711 silly get     age: '17',
+1711 silly get     connection: 'keep-alive',
+1711 silly get     'x-served-by': 'cache-lax1427-LAX',
+1711 silly get     'x-cache': 'HIT',
+1711 silly get     'x-cache-hits': '61',
+1711 silly get     'x-timer': 'S1437673558.483418,VS0,VE0',
+1711 silly get     vary: 'Accept' } ]
+1712 verbose get saving karma-phantomjs-launcher to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-phantomjs-launcher\.cache.json
+1713 http 304 https://registry.npmjs.org/body-parser
+1714 silly get cb [ 304,
+1714 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1714 silly get     via: '1.1 varnish',
+1714 silly get     'cache-control': 'max-age=60',
+1714 silly get     etag: '"6FCHYAC6NAF1MURHAEN0Q74FO"',
+1714 silly get     age: '50',
+1714 silly get     connection: 'keep-alive',
+1714 silly get     'x-served-by': 'cache-lax1430-LAX',
+1714 silly get     'x-cache': 'HIT',
+1714 silly get     'x-cache-hits': '3',
+1714 silly get     'x-timer': 'S1437673558.484700,VS0,VE0',
+1714 silly get     vary: 'Accept' } ]
+1715 verbose etag https://registry.npmjs.org/body-parser from cache
+1716 verbose get saving body-parser to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\body-parser\.cache.json
+1717 http 200 https://registry.npmjs.org/jshint-stylish
+1718 silly get cb [ 200,
+1718 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1718 silly get     etag: '"DOS3TL2LDR5679N0845Z2FB6I"',
+1718 silly get     'content-type': 'application/json',
+1718 silly get     'cache-control': 'max-age=60',
+1718 silly get     'content-length': '18698',
+1718 silly get     'accept-ranges': 'bytes',
+1718 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1718 silly get     via: '1.1 varnish',
+1718 silly get     age: '49',
+1718 silly get     connection: 'keep-alive',
+1718 silly get     'x-served-by': 'cache-lax1431-LAX',
+1718 silly get     'x-cache': 'HIT',
+1718 silly get     'x-cache-hits': '1',
+1718 silly get     'x-timer': 'S1437673558.484466,VS0,VE0',
+1718 silly get     vary: 'Accept' } ]
+1719 verbose get saving jshint-stylish to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\jshint-stylish\.cache.json
+1720 http 304 https://registry.npmjs.org/grunt-google-cdn
+1721 silly get cb [ 304,
+1721 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1721 silly get     via: '1.1 varnish',
+1721 silly get     'cache-control': 'max-age=60',
+1721 silly get     etag: '"98AMV143LFZ81CXMJP6SGCNQT"',
+1721 silly get     age: '0',
+1721 silly get     connection: 'keep-alive',
+1721 silly get     'x-served-by': 'cache-lax1431-LAX',
+1721 silly get     'x-cache': 'HIT',
+1721 silly get     'x-cache-hits': '1',
+1721 silly get     'x-timer': 'S1437673558.425042,VS0,VE75',
+1721 silly get     vary: 'Accept' } ]
+1722 verbose etag https://registry.npmjs.org/grunt-google-cdn from cache
+1723 verbose get saving grunt-google-cdn to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-google-cdn\.cache.json
+1724 http 304 https://registry.npmjs.org/karma-script-launcher
+1725 silly get cb [ 304,
+1725 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1725 silly get     via: '1.1 varnish',
+1725 silly get     'cache-control': 'max-age=60',
+1725 silly get     etag: '"B7K7G6UQ3EPBF6VMO7AP9CU9H"',
+1725 silly get     age: '0',
+1725 silly get     connection: 'keep-alive',
+1725 silly get     'x-served-by': 'cache-lax1425-LAX',
+1725 silly get     'x-cache': 'HIT',
+1725 silly get     'x-cache-hits': '1',
+1725 silly get     'x-timer': 'S1437673558.454506,VS0,VE47',
+1725 silly get     vary: 'Accept' } ]
+1726 verbose etag https://registry.npmjs.org/karma-script-launcher from cache
+1727 verbose get saving karma-script-launcher to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-script-launcher\.cache.json
+1728 http 304 https://registry.npmjs.org/karma-jade-preprocessor
+1729 silly get cb [ 304,
+1729 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1729 silly get     via: '1.1 varnish',
+1729 silly get     'cache-control': 'max-age=60',
+1729 silly get     etag: '"6VG2VUOXWCRGN379BQUHTTD5L"',
+1729 silly get     age: '0',
+1729 silly get     connection: 'keep-alive',
+1729 silly get     'x-served-by': 'cache-lax1434-LAX',
+1729 silly get     'x-cache': 'MISS',
+1729 silly get     'x-cache-hits': '0',
+1729 silly get     'x-timer': 'S1437673558.454419,VS0,VE47',
+1729 silly get     vary: 'Accept' } ]
+1730 verbose etag https://registry.npmjs.org/karma-jade-preprocessor from cache
+1731 verbose get saving karma-jade-preprocessor to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-jade-preprocessor\.cache.json
+1732 http 304 https://registry.npmjs.org/grunt-protractor-runner
+1733 silly get cb [ 304,
+1733 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1733 silly get     via: '1.1 varnish',
+1733 silly get     'cache-control': 'max-age=60',
+1733 silly get     etag: '"6UR3K00J92QSFV97JNBUDWNZ1"',
+1733 silly get     age: '0',
+1733 silly get     connection: 'keep-alive',
+1733 silly get     'x-served-by': 'cache-lax1435-LAX',
+1733 silly get     'x-cache': 'HIT',
+1733 silly get     'x-cache-hits': '1',
+1733 silly get     'x-timer': 'S1437673558.424126,VS0,VE83',
+1733 silly get     vary: 'Accept' } ]
+1734 verbose etag https://registry.npmjs.org/grunt-protractor-runner from cache
+1735 verbose get saving grunt-protractor-runner to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-protractor-runner\.cache.json
+1736 http 200 https://registry.npmjs.org/grunt-contrib-cssmin
+1737 silly get cb [ 200,
+1737 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1737 silly get     etag: '"1ITPTI9ELV2USDTWQOMMRGTTX"',
+1737 silly get     'content-type': 'application/json',
+1737 silly get     'cache-control': 'max-age=60',
+1737 silly get     'content-length': '35476',
+1737 silly get     'accept-ranges': 'bytes',
+1737 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1737 silly get     via: '1.1 varnish',
+1737 silly get     age: '49',
+1737 silly get     connection: 'keep-alive',
+1737 silly get     'x-served-by': 'cache-lax1435-LAX',
+1737 silly get     'x-cache': 'HIT',
+1737 silly get     'x-cache-hits': '2',
+1737 silly get     'x-timer': 'S1437673558.309342,VS0,VE0',
+1737 silly get     vary: 'Accept' } ]
+1738 verbose get saving grunt-contrib-cssmin to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-cssmin\.cache.json
+1739 http 304 https://registry.npmjs.org/passport-google-oauth
+1740 silly get cb [ 304,
+1740 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1740 silly get     via: '1.1 varnish',
+1740 silly get     'cache-control': 'max-age=60',
+1740 silly get     etag: '"8ICS6HTVCRGSX6FAHP8Q2ZW2Z"',
+1740 silly get     age: '0',
+1740 silly get     connection: 'keep-alive',
+1740 silly get     'x-served-by': 'cache-lax1433-LAX',
+1740 silly get     'x-cache': 'HIT',
+1740 silly get     'x-cache-hits': '1',
+1740 silly get     'x-timer': 'S1437673558.516008,VS0,VE0',
+1740 silly get     vary: 'Accept' } ]
+1741 verbose etag https://registry.npmjs.org/passport-google-oauth from cache
+1742 verbose get saving passport-google-oauth to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\passport-google-oauth\.cache.json
+1743 http 200 https://registry.npmjs.org/grunt-contrib-jade
+1744 silly get cb [ 200,
+1744 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1744 silly get     etag: '"9KJEGXLQVHUBUT64KJPY2PIOZ"',
+1744 silly get     'content-type': 'application/json',
+1744 silly get     'cache-control': 'max-age=60',
+1744 silly get     'content-length': '42550',
+1744 silly get     'accept-ranges': 'bytes',
+1744 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1744 silly get     via: '1.1 varnish',
+1744 silly get     age: '0',
+1744 silly get     connection: 'keep-alive',
+1744 silly get     'x-served-by': 'cache-lax1431-LAX',
+1744 silly get     'x-cache': 'HIT',
+1744 silly get     'x-cache-hits': '1',
+1744 silly get     'x-timer': 'S1437673558.306494,VS0,VE45',
+1744 silly get     vary: 'Accept' } ]
+1745 verbose get saving grunt-contrib-jade to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-jade\.cache.json
+1746 http 200 https://registry.npmjs.org/jit-grunt
+1747 silly get cb [ 200,
+1747 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1747 silly get     etag: '"3L4XS3BPAZ7IDJNKX2ZZPPJMX"',
+1747 silly get     'content-type': 'application/json',
+1747 silly get     'cache-control': 'max-age=60',
+1747 silly get     'content-length': '30488',
+1747 silly get     'accept-ranges': 'bytes',
+1747 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1747 silly get     via: '1.1 varnish',
+1747 silly get     age: '0',
+1747 silly get     connection: 'keep-alive',
+1747 silly get     'x-served-by': 'cache-lax1422-LAX',
+1747 silly get     'x-cache': 'HIT',
+1747 silly get     'x-cache-hits': '1',
+1747 silly get     'x-timer': 'S1437673558.451506,VS0,VE83',
+1747 silly get     vary: 'Accept' } ]
+1748 verbose get saving jit-grunt to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\jit-grunt\.cache.json
+1749 silly mapToRegistry name fs-finder
+1750 silly mapToRegistry using default registry
+1751 silly mapToRegistry registry https://registry.npmjs.org/
+1752 silly mapToRegistry uri https://registry.npmjs.org/fs-finder
+1753 verbose addRemoteTarball https://registry.npmjs.org/fs-finder/-/fs-finder-1.8.1.tgz not in flight; adding
+1754 verbose addRemoteTarball [ 'https://registry.npmjs.org/fs-finder/-/fs-finder-1.8.1.tgz',
+1754 verbose addRemoteTarball   '106fea8aa89d0af343360663d5855862cae1b874' ]
+1755 http 304 https://registry.npmjs.org/open
+1756 silly get cb [ 304,
+1756 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1756 silly get     via: '1.1 varnish',
+1756 silly get     'cache-control': 'max-age=60',
+1756 silly get     etag: '"2YZQBX1A1E9EQNG5KX4UZRS3B"',
+1756 silly get     age: '0',
+1756 silly get     connection: 'keep-alive',
+1756 silly get     'x-served-by': 'cache-lax1432-LAX',
+1756 silly get     'x-cache': 'HIT',
+1756 silly get     'x-cache-hits': '1',
+1756 silly get     'x-timer': 'S1437673558.510205,VS0,VE44',
+1756 silly get     vary: 'Accept' } ]
+1757 verbose etag https://registry.npmjs.org/open from cache
+1758 verbose get saving open to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\open\.cache.json
+1759 http 304 https://registry.npmjs.org/karma-ng-jade2js-preprocessor
+1760 silly get cb [ 304,
+1760 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1760 silly get     via: '1.1 varnish',
+1760 silly get     'cache-control': 'max-age=60',
+1760 silly get     etag: '"20AZLLXX6LOKRKYVIWFGVJI6Q"',
+1760 silly get     age: '0',
+1760 silly get     connection: 'keep-alive',
+1760 silly get     'x-served-by': 'cache-lax1433-LAX',
+1760 silly get     'x-cache': 'HIT',
+1760 silly get     'x-cache-hits': '1',
+1760 silly get     'x-timer': 'S1437673558.481161,VS0,VE75',
+1760 silly get     vary: 'Accept' } ]
+1761 verbose etag https://registry.npmjs.org/karma-ng-jade2js-preprocessor from cache
+1762 verbose get saving karma-ng-jade2js-preprocessor to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-ng-jade2js-preprocessor\.cache.json
+1763 http 304 https://registry.npmjs.org/karma-ng-scenario
+1764 silly get cb [ 304,
+1764 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1764 silly get     via: '1.1 varnish',
+1764 silly get     'cache-control': 'max-age=60',
+1764 silly get     etag: '"BQOIIG3JX8DCWK38WYE21RZ2R"',
+1764 silly get     age: '0',
+1764 silly get     connection: 'keep-alive',
+1764 silly get     'x-served-by': 'cache-lax1424-LAX',
+1764 silly get     'x-cache': 'HIT',
+1764 silly get     'x-cache-hits': '1',
+1764 silly get     'x-timer': 'S1437673558.479982,VS0,VE75',
+1764 silly get     vary: 'Accept' } ]
+1765 verbose etag https://registry.npmjs.org/karma-ng-scenario from cache
+1766 verbose get saving karma-ng-scenario to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-ng-scenario\.cache.json
+1767 http 200 https://registry.npmjs.org/compression
+1768 silly get cb [ 200,
+1768 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1768 silly get     etag: '"DOF5H2LE4WS5AYNE6RD3NP0I2"',
+1768 silly get     'content-type': 'application/json',
+1768 silly get     'cache-control': 'max-age=60',
+1768 silly get     'content-length': '56271',
+1768 silly get     'accept-ranges': 'bytes',
+1768 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1768 silly get     via: '1.1 varnish',
+1768 silly get     age: '0',
+1768 silly get     connection: 'keep-alive',
+1768 silly get     'x-served-by': 'cache-lax1426-LAX',
+1768 silly get     'x-cache': 'HIT',
+1768 silly get     'x-cache-hits': '1',
+1768 silly get     'x-timer': 'S1437673558.510486,VS0,VE45',
+1768 silly get     vary: 'Accept' } ]
+1769 verbose get saving compression to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\compression\.cache.json
+1770 http 200 https://registry.npmjs.org/karma-coffee-preprocessor
+1771 silly get cb [ 200,
+1771 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1771 silly get     etag: '"3TSPDRQRRYXZFHZM3LCCHFA65"',
+1771 silly get     'content-type': 'application/json',
+1771 silly get     'cache-control': 'max-age=60',
+1771 silly get     'content-length': '19808',
+1771 silly get     'accept-ranges': 'bytes',
+1771 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1771 silly get     via: '1.1 varnish',
+1771 silly get     age: '0',
+1771 silly get     connection: 'keep-alive',
+1771 silly get     'x-served-by': 'cache-lax1431-LAX',
+1771 silly get     'x-cache': 'HIT',
+1771 silly get     'x-cache-hits': '1',
+1771 silly get     'x-timer': 'S1437673558.511206,VS0,VE49',
+1771 silly get     vary: 'Accept' } ]
+1772 verbose get saving karma-coffee-preprocessor to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-coffee-preprocessor\.cache.json
+1773 http 200 https://registry.npmjs.org/passport-twitter
+1774 silly get cb [ 200,
+1774 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1774 silly get     etag: '"3HGABJ5Z5TMH05PJRJCMYNVD1"',
+1774 silly get     'content-type': 'application/json',
+1774 silly get     'cache-control': 'max-age=60',
+1774 silly get     'content-length': '16290',
+1774 silly get     'accept-ranges': 'bytes',
+1774 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1774 silly get     via: '1.1 varnish',
+1774 silly get     age: '0',
+1774 silly get     connection: 'keep-alive',
+1774 silly get     'x-served-by': 'cache-lax1430-LAX',
+1774 silly get     'x-cache': 'HIT',
+1774 silly get     'x-cache-hits': '1',
+1774 silly get     'x-timer': 'S1437673558.515535,VS0,VE48',
+1774 silly get     vary: 'Accept' } ]
+1775 verbose get saving passport-twitter to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\passport-twitter\.cache.json
+1776 http 200 https://registry.npmjs.org/grunt-ng-annotate
+1777 silly get cb [ 200,
+1777 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1777 silly get     etag: '"2SGSNB1NTO6WNE5FVRIUWXMUV"',
+1777 silly get     'content-type': 'application/json',
+1777 silly get     'cache-control': 'max-age=60',
+1777 silly get     'content-length': '42279',
+1777 silly get     'accept-ranges': 'bytes',
+1777 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1777 silly get     via: '1.1 varnish',
+1777 silly get     age: '49',
+1777 silly get     connection: 'keep-alive',
+1777 silly get     'x-served-by': 'cache-lax1426-LAX',
+1777 silly get     'x-cache': 'HIT',
+1777 silly get     'x-cache-hits': '1',
+1777 silly get     'x-timer': 'S1437673558.403723,VS0,VE0',
+1777 silly get     vary: 'Accept' } ]
+1778 verbose get saving grunt-ng-annotate to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-ng-annotate\.cache.json
+1779 http 304 https://registry.npmjs.org/composable-middleware
+1780 silly get cb [ 304,
+1780 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1780 silly get     via: '1.1 varnish',
+1780 silly get     'cache-control': 'max-age=60',
+1780 silly get     etag: '"4X9R0RAP8K2O62TZP53K1FHQZ"',
+1780 silly get     age: '0',
+1780 silly get     connection: 'keep-alive',
+1780 silly get     'x-served-by': 'cache-lax1424-LAX',
+1780 silly get     'x-cache': 'HIT',
+1780 silly get     'x-cache-hits': '1',
+1780 silly get     'x-timer': 'S1437673558.514686,VS0,VE77',
+1780 silly get     vary: 'Accept' } ]
+1781 verbose etag https://registry.npmjs.org/composable-middleware from cache
+1782 verbose get saving composable-middleware to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\composable-middleware\.cache.json
+1783 http 200 https://registry.npmjs.org/grunt-wiredep
+1784 silly get cb [ 200,
+1784 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1784 silly get     etag: '"64Z8KP8JQU7FNT7C8X52NAH0W"',
+1784 silly get     'content-type': 'application/json',
+1784 silly get     'cache-control': 'max-age=60',
+1784 silly get     'content-length': '10697',
+1784 silly get     'accept-ranges': 'bytes',
+1784 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1784 silly get     via: '1.1 varnish',
+1784 silly get     age: '0',
+1784 silly get     connection: 'keep-alive',
+1784 silly get     'x-served-by': 'cache-lax1435-LAX',
+1784 silly get     'x-cache': 'HIT',
+1784 silly get     'x-cache-hits': '1',
+1784 silly get     'x-timer': 'S1437673558.419566,VS0,VE178',
+1784 silly get     vary: 'Accept' } ]
+1785 verbose get saving grunt-wiredep to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-wiredep\.cache.json
+1786 http 304 https://registry.npmjs.org/grunt-open
+1787 silly get cb [ 304,
+1787 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1787 silly get     via: '1.1 varnish',
+1787 silly get     'cache-control': 'max-age=60',
+1787 silly get     etag: '"BNU65HXCNE4TUUNNC619W8VGR"',
+1787 silly get     age: '0',
+1787 silly get     connection: 'keep-alive',
+1787 silly get     'x-served-by': 'cache-lax1422-LAX',
+1787 silly get     'x-cache': 'HIT',
+1787 silly get     'x-cache-hits': '1',
+1787 silly get     'x-timer': 'S1437673558.426217,VS0,VE191',
+1787 silly get     vary: 'Accept' } ]
+1788 verbose etag https://registry.npmjs.org/grunt-open from cache
+1789 verbose get saving grunt-open to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-open\.cache.json
+1790 http 200 https://registry.npmjs.org/grunt-env
+1791 silly get cb [ 200,
+1791 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1791 silly get     etag: '"9EITEHGFY6QVAQQKOJQ1HZIJO"',
+1791 silly get     'content-type': 'application/json',
+1791 silly get     'cache-control': 'max-age=60',
+1791 silly get     'content-length': '15222',
+1791 silly get     'accept-ranges': 'bytes',
+1791 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1791 silly get     via: '1.1 varnish',
+1791 silly get     age: '0',
+1791 silly get     connection: 'keep-alive',
+1791 silly get     'x-served-by': 'cache-lax1431-LAX',
+1791 silly get     'x-cache': 'MISS',
+1791 silly get     'x-cache-hits': '0',
+1791 silly get     'x-timer': 'S1437673558.404399,VS0,VE230',
+1791 silly get     vary: 'Accept' } ]
+1792 verbose get saving grunt-env to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-env\.cache.json
+1793 http 200 https://registry.npmjs.org/grunt-svgmin
+1794 silly get cb [ 200,
+1794 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1794 silly get     etag: '"9FSKI3RKKA2AM5U24KKGPKHTR"',
+1794 silly get     'content-type': 'application/json',
+1794 silly get     'cache-control': 'max-age=60',
+1794 silly get     'content-length': '14009',
+1794 silly get     'accept-ranges': 'bytes',
+1794 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1794 silly get     via: '1.1 varnish',
+1794 silly get     age: '0',
+1794 silly get     connection: 'keep-alive',
+1794 silly get     'x-served-by': 'cache-lax1433-LAX',
+1794 silly get     'x-cache': 'HIT',
+1794 silly get     'x-cache-hits': '1',
+1794 silly get     'x-timer': 'S1437673558.455144,VS0,VE183',
+1794 silly get     vary: 'Accept' } ]
+1795 verbose get saving grunt-svgmin to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-svgmin\.cache.json
+1796 http 200 https://registry.npmjs.org/karma-jasmine
+1797 silly get cb [ 200,
+1797 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1797 silly get     etag: '"2J6UAR9NXZPCFGE8G52CPBZOW"',
+1797 silly get     'content-type': 'application/json',
+1797 silly get     'cache-control': 'max-age=60',
+1797 silly get     'content-length': '35059',
+1797 silly get     'accept-ranges': 'bytes',
+1797 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1797 silly get     via: '1.1 varnish',
+1797 silly get     age: '0',
+1797 silly get     connection: 'keep-alive',
+1797 silly get     'x-served-by': 'cache-lax1430-LAX',
+1797 silly get     'x-cache': 'HIT',
+1797 silly get     'x-cache-hits': '1',
+1797 silly get     'x-timer': 'S1437673558.457225,VS0,VE186',
+1797 silly get     vary: 'Accept' } ]
+1798 verbose get saving karma-jasmine to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-jasmine\.cache.json
+1799 http 200 https://registry.npmjs.org/karma-ng-html2js-preprocessor
+1800 silly get cb [ 200,
+1800 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1800 silly get     etag: '"5Q06SBWFZWPG881L5VUAJE6KQ"',
+1800 silly get     'content-type': 'application/json',
+1800 silly get     'cache-control': 'max-age=60',
+1800 silly get     'content-length': '15122',
+1800 silly get     'accept-ranges': 'bytes',
+1800 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1800 silly get     via: '1.1 varnish',
+1800 silly get     age: '0',
+1800 silly get     connection: 'keep-alive',
+1800 silly get     'x-served-by': 'cache-lax1434-LAX',
+1800 silly get     'x-cache': 'HIT',
+1800 silly get     'x-cache-hits': '1',
+1800 silly get     'x-timer': 'S1437673558.510299,VS0,VE187',
+1800 silly get     vary: 'Accept' } ]
+1801 verbose get saving karma-ng-html2js-preprocessor to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-ng-html2js-preprocessor\.cache.json
+1802 http 304 https://registry.npmjs.org/grunt-asset-injector
+1803 silly get cb [ 304,
+1803 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1803 silly get     via: '1.1 varnish',
+1803 silly get     'cache-control': 'max-age=60',
+1803 silly get     etag: '"7TQ3ESNB99Q74J9U5ADQLVOUT"',
+1803 silly get     age: '0',
+1803 silly get     connection: 'keep-alive',
+1803 silly get     'x-served-by': 'cache-lax1432-LAX',
+1803 silly get     'x-cache': 'MISS',
+1803 silly get     'x-cache-hits': '0',
+1803 silly get     'x-timer': 'S1437673558.384036,VS0,VE337',
+1803 silly get     vary: 'Accept' } ]
+1804 verbose etag https://registry.npmjs.org/grunt-asset-injector from cache
+1805 verbose get saving grunt-asset-injector to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-asset-injector\.cache.json
+1806 http 200 https://registry.npmjs.org/grunt-newer
+1807 silly get cb [ 200,
+1807 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1807 silly get     etag: '"E47FNUIE3MBKI3MRN9764I3E9"',
+1807 silly get     'content-type': 'application/json',
+1807 silly get     'cache-control': 'max-age=60',
+1807 silly get     'content-length': '31006',
+1807 silly get     'accept-ranges': 'bytes',
+1807 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1807 silly get     via: '1.1 varnish',
+1807 silly get     age: '0',
+1807 silly get     connection: 'keep-alive',
+1807 silly get     'x-served-by': 'cache-lax1420-LAX',
+1807 silly get     'x-cache': 'HIT',
+1807 silly get     'x-cache-hits': '1',
+1807 silly get     'x-timer': 'S1437673558.424607,VS0,VE302',
+1807 silly get     vary: 'Accept' } ]
+1808 verbose get saving grunt-newer to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-newer\.cache.json
+1809 http 200 https://registry.npmjs.org/karma-firefox-launcher
+1810 silly get cb [ 200,
+1810 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1810 silly get     etag: '"3MMZLKHQEIWIA2YJRAX32ZK8S"',
+1810 silly get     'content-type': 'application/json',
+1810 silly get     'cache-control': 'max-age=60',
+1810 silly get     'content-length': '19599',
+1810 silly get     'accept-ranges': 'bytes',
+1810 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1810 silly get     via: '1.1 varnish',
+1810 silly get     age: '0',
+1810 silly get     connection: 'keep-alive',
+1810 silly get     'x-served-by': 'cache-lax1434-LAX',
+1810 silly get     'x-cache': 'HIT',
+1810 silly get     'x-cache-hits': '1',
+1810 silly get     'x-timer': 'S1437673558.457826,VS0,VE306',
+1810 silly get     vary: 'Accept' } ]
+1811 verbose get saving karma-firefox-launcher to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-firefox-launcher\.cache.json
+1812 http 200 https://registry.npmjs.org/karma-html2js-preprocessor
+1813 silly get cb [ 200,
+1813 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1813 silly get     etag: '"A6G29KNCT4Z44170ZIK4N61JF"',
+1813 silly get     'content-type': 'application/json',
+1813 silly get     'cache-control': 'max-age=60',
+1813 silly get     'content-length': '6236',
+1813 silly get     'accept-ranges': 'bytes',
+1813 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1813 silly get     via: '1.1 varnish',
+1813 silly get     age: '0',
+1813 silly get     connection: 'keep-alive',
+1813 silly get     'x-served-by': 'cache-lax1430-LAX',
+1813 silly get     'x-cache': 'HIT',
+1813 silly get     'x-cache-hits': '1',
+1813 silly get     'x-timer': 'S1437673558.455042,VS0,VE330',
+1813 silly get     vary: 'Accept' } ]
+1814 verbose get saving karma-html2js-preprocessor to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-html2js-preprocessor\.cache.json
+1815 http 304 https://registry.npmjs.org/grunt-contrib-clean
+1816 silly get cb [ 304,
+1816 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1816 silly get     via: '1.1 varnish',
+1816 silly get     'cache-control': 'max-age=60',
+1816 silly get     etag: '"2FBLHFZX5VK8P9YZ36QGSJQXV"',
+1816 silly get     age: '0',
+1816 silly get     connection: 'keep-alive',
+1816 silly get     'x-served-by': 'cache-lax1420-LAX',
+1816 silly get     'x-cache': 'HIT',
+1816 silly get     'x-cache-hits': '1',
+1816 silly get     'x-timer': 'S1437673558.791654,VS0,VE0',
+1816 silly get     vary: 'Accept' } ]
+1817 verbose etag https://registry.npmjs.org/grunt-contrib-clean from cache
+1818 verbose get saving grunt-contrib-clean to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-clean\.cache.json
+1819 http 200 https://registry.npmjs.org/fs-extra
+1820 silly get cb [ 200,
+1820 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1820 silly get     etag: '"F4M8XAM1GVHHG82ZZ3RCYII4T"',
+1820 silly get     'content-type': 'application/json',
+1820 silly get     'cache-control': 'max-age=60',
+1820 silly get     'content-length': '87576',
+1820 silly get     'accept-ranges': 'bytes',
+1820 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1820 silly get     via: '1.1 varnish',
+1820 silly get     age: '45',
+1820 silly get     connection: 'keep-alive',
+1820 silly get     'x-served-by': 'cache-lax1430-LAX',
+1820 silly get     'x-cache': 'HIT',
+1820 silly get     'x-cache-hits': '2',
+1820 silly get     'x-timer': 'S1437673558.301548,VS0,VE0',
+1820 silly get     vary: 'Accept' } ]
+1821 verbose get saving fs-extra to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\fs-extra\.cache.json
+1822 http 200 https://registry.npmjs.org/passport-facebook
+1823 silly get cb [ 200,
+1823 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1823 silly get     etag: '"F3265VV3O824DJGMUWHI53C9L"',
+1823 silly get     'content-type': 'application/json',
+1823 silly get     'cache-control': 'max-age=60',
+1823 silly get     'content-length': '21352',
+1823 silly get     'accept-ranges': 'bytes',
+1823 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1823 silly get     via: '1.1 varnish',
+1823 silly get     age: '11',
+1823 silly get     connection: 'keep-alive',
+1823 silly get     'x-served-by': 'cache-lax1420-LAX',
+1823 silly get     'x-cache': 'HIT',
+1823 silly get     'x-cache-hits': '1',
+1823 silly get     'x-timer': 'S1437673558.795776,VS0,VE0',
+1823 silly get     vary: 'Accept' } ]
+1824 verbose get saving passport-facebook to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\passport-facebook\.cache.json
+1825 http 200 https://registry.npmjs.org/requirejs
+1826 silly get cb [ 200,
+1826 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1826 silly get     etag: '"6Y0AR3IXYFAXD01KDU9PXKAFN"',
+1826 silly get     'content-type': 'application/json',
+1826 silly get     'cache-control': 'max-age=60',
+1826 silly get     'content-length': '40391',
+1826 silly get     'accept-ranges': 'bytes',
+1826 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1826 silly get     via: '1.1 varnish',
+1826 silly get     age: '20',
+1826 silly get     connection: 'keep-alive',
+1826 silly get     'x-served-by': 'cache-lax1428-LAX',
+1826 silly get     'x-cache': 'HIT',
+1826 silly get     'x-cache-hits': '1',
+1826 silly get     'x-timer': 'S1437673558.505529,VS0,VE1',
+1826 silly get     vary: 'Accept' } ]
+1827 verbose get saving requirejs to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\requirejs\.cache.json
+1828 http 200 https://registry.npmjs.org/grunt-usemin
+1829 silly get cb [ 200,
+1829 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1829 silly get     etag: '"B74QKOG3LWP7OYAB0ABCEG3Q8"',
+1829 silly get     'content-type': 'application/json',
+1829 silly get     'cache-control': 'max-age=60',
+1829 silly get     'content-length': '60585',
+1829 silly get     'accept-ranges': 'bytes',
+1829 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1829 silly get     via: '1.1 varnish',
+1829 silly get     age: '0',
+1829 silly get     connection: 'keep-alive',
+1829 silly get     'x-served-by': 'cache-lax1423-LAX',
+1829 silly get     'x-cache': 'HIT',
+1829 silly get     'x-cache-hits': '1',
+1829 silly get     'x-timer': 'S1437673558.424070,VS0,VE83',
+1829 silly get     vary: 'Accept' } ]
+1830 verbose get saving grunt-usemin to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-usemin\.cache.json
+1831 http 200 https://registry.npmjs.org/grunt-contrib-uglify
+1832 silly get cb [ 200,
+1832 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1832 silly get     etag: '"5AN2566H272KR6JUNT09LVDRI"',
+1832 silly get     'content-type': 'application/json',
+1832 silly get     'cache-control': 'max-age=60',
+1832 silly get     'content-length': '65862',
+1832 silly get     'accept-ranges': 'bytes',
+1832 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1832 silly get     via: '1.1 varnish',
+1832 silly get     age: '25',
+1832 silly get     connection: 'keep-alive',
+1832 silly get     'x-served-by': 'cache-lax1433-LAX',
+1832 silly get     'x-cache': 'HIT',
+1832 silly get     'x-cache-hits': '1',
+1832 silly get     'x-timer': 'S1437673558.511768,VS0,VE0',
+1832 silly get     vary: 'Accept' } ]
+1833 verbose get saving grunt-contrib-uglify to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-uglify\.cache.json
+1834 http 200 https://registry.npmjs.org/connect-mongo
+1835 silly get cb [ 200,
+1835 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1835 silly get     etag: '"DQJK5FO89NUS8T6GA389UXU7W"',
+1835 silly get     'content-type': 'application/json',
+1835 silly get     'cache-control': 'max-age=60',
+1835 silly get     'content-length': '37516',
+1835 silly get     'accept-ranges': 'bytes',
+1835 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1835 silly get     via: '1.1 varnish',
+1835 silly get     age: '46',
+1835 silly get     connection: 'keep-alive',
+1835 silly get     'x-served-by': 'cache-lax1422-LAX',
+1835 silly get     'x-cache': 'HIT',
+1835 silly get     'x-cache-hits': '1',
+1835 silly get     'x-timer': 'S1437673558.512438,VS0,VE0',
+1835 silly get     vary: 'Accept' } ]
+1836 verbose get saving connect-mongo to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\connect-mongo\.cache.json
+1837 http 200 https://registry.npmjs.org/karma-requirejs
+1838 silly get cb [ 200,
+1838 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1838 silly get     etag: '"DGAQWPBK4P81I4J9VTTOXSO07"',
+1838 silly get     'content-type': 'application/json',
+1838 silly get     'cache-control': 'max-age=60',
+1838 silly get     'content-length': '10489',
+1838 silly get     'accept-ranges': 'bytes',
+1838 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1838 silly get     via: '1.1 varnish',
+1838 silly get     age: '0',
+1838 silly get     connection: 'keep-alive',
+1838 silly get     'x-served-by': 'cache-lax1425-LAX',
+1838 silly get     'x-cache': 'HIT',
+1838 silly get     'x-cache-hits': '1',
+1838 silly get     'x-timer': 'S1437673558.484371,VS0,VE334',
+1838 silly get     vary: 'Accept' } ]
+1839 verbose get saving karma-requirejs to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma-requirejs\.cache.json
+1840 http 200 https://registry.npmjs.org/chokidar
+1841 silly get cb [ 200,
+1841 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1841 silly get     etag: '"AHKVEVVMPP9ZFLLU8W0UNR0DD"',
+1841 silly get     'content-type': 'application/json',
+1841 silly get     'cache-control': 'max-age=60',
+1841 silly get     'content-length': '87390',
+1841 silly get     'accept-ranges': 'bytes',
+1841 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1841 silly get     via: '1.1 varnish',
+1841 silly get     age: '29',
+1841 silly get     connection: 'keep-alive',
+1841 silly get     'x-served-by': 'cache-lax1427-LAX',
+1841 silly get     'x-cache': 'HIT',
+1841 silly get     'x-cache-hits': '1',
+1841 silly get     'x-timer': 'S1437673558.513573,VS0,VE1',
+1841 silly get     vary: 'Accept' } ]
+1842 verbose get saving chokidar to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\chokidar\.cache.json
+1843 info retry fetch attempt 1 at 10:46:00 AM
+1844 info attempt registry request try #1 at 10:46:00 AM
+1845 http fetch GET https://registry.npmjs.org/xml-to-json/-/xml-to-json-0.1.1.tgz
+1846 http 304 https://registry.npmjs.org/grunt-contrib-copy
+1847 silly get cb [ 304,
+1847 silly get   { date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1847 silly get     via: '1.1 varnish',
+1847 silly get     'cache-control': 'max-age=60',
+1847 silly get     etag: '"6AP11BYFAUTO2KJVRSF7YLXW9"',
+1847 silly get     age: '50',
+1847 silly get     connection: 'keep-alive',
+1847 silly get     'x-served-by': 'cache-lax1428-LAX',
+1847 silly get     'x-cache': 'HIT',
+1847 silly get     'x-cache-hits': '2',
+1847 silly get     'x-timer': 'S1437673558.817696,VS0,VE0',
+1847 silly get     vary: 'Accept' } ]
+1848 verbose etag https://registry.npmjs.org/grunt-contrib-copy from cache
+1849 verbose get saving grunt-contrib-copy to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-copy\.cache.json
+1850 http 200 https://registry.npmjs.org/supertest
+1851 silly get cb [ 200,
+1851 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1851 silly get     etag: '"9VGL7YYEORA2J5GCQ7SI53Y8Q"',
+1851 silly get     'content-type': 'application/json',
+1851 silly get     'cache-control': 'max-age=60',
+1851 silly get     'content-length': '36863',
+1851 silly get     'accept-ranges': 'bytes',
+1851 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1851 silly get     via: '1.1 varnish',
+1851 silly get     age: '46',
+1851 silly get     connection: 'keep-alive',
+1851 silly get     'x-served-by': 'cache-lax1423-LAX',
+1851 silly get     'x-cache': 'HIT',
+1851 silly get     'x-cache-hits': '1',
+1851 silly get     'x-timer': 'S1437673558.509911,VS0,VE2',
+1851 silly get     vary: 'Accept' } ]
+1852 verbose get saving supertest to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\supertest\.cache.json
+1853 http 200 https://registry.npmjs.org/time-grunt
+1854 silly get cb [ 200,
+1854 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1854 silly get     etag: '"EJAYJ2YEXTUBWOOFZAGXOAS0Z"',
+1854 silly get     'content-type': 'application/json',
+1854 silly get     'cache-control': 'max-age=60',
+1854 silly get     'content-length': '28020',
+1854 silly get     'accept-ranges': 'bytes',
+1854 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1854 silly get     via: '1.1 varnish',
+1854 silly get     age: '17',
+1854 silly get     connection: 'keep-alive',
+1854 silly get     'x-served-by': 'cache-lax1431-LAX',
+1854 silly get     'x-cache': 'HIT',
+1854 silly get     'x-cache-hits': '1',
+1854 silly get     'x-timer': 'S1437673558.515278,VS0,VE0',
+1854 silly get     vary: 'Accept' } ]
+1855 verbose get saving time-grunt to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\time-grunt\.cache.json
+1856 info retry fetch attempt 1 at 10:46:00 AM
+1857 info attempt registry request try #1 at 10:46:00 AM
+1858 http fetch GET https://registry.npmjs.org/mongoose-text-search/-/mongoose-text-search-0.0.2.tgz
+1859 http 200 https://registry.npmjs.org/grunt
+1860 silly get cb [ 200,
+1860 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1860 silly get     etag: '"9YSBSFWKMV3P9P6UN2DFJCRJ9"',
+1860 silly get     'content-type': 'application/json',
+1860 silly get     'cache-control': 'max-age=60',
+1860 silly get     'content-length': '89723',
+1860 silly get     'accept-ranges': 'bytes',
+1860 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1860 silly get     via: '1.1 varnish',
+1860 silly get     age: '31',
+1860 silly get     connection: 'keep-alive',
+1860 silly get     'x-served-by': 'cache-lax1424-LAX',
+1860 silly get     'x-cache': 'HIT',
+1860 silly get     'x-cache-hits': '1',
+1860 silly get     'x-timer': 'S1437673558.375514,VS0,VE1',
+1860 silly get     vary: 'Accept' } ]
+1861 verbose get saving grunt to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt\.cache.json
+1862 http 200 https://registry.npmjs.org/grunt-express-server
+1863 silly get cb [ 200,
+1863 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1863 silly get     etag: '"2G379ZHQGUPBCRNNXY2C50PN3"',
+1863 silly get     'content-type': 'application/json',
+1863 silly get     'cache-control': 'max-age=60',
+1863 silly get     'content-length': '45391',
+1863 silly get     'accept-ranges': 'bytes',
+1863 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1863 silly get     via: '1.1 varnish',
+1863 silly get     age: '0',
+1863 silly get     connection: 'keep-alive',
+1863 silly get     'x-served-by': 'cache-lax1420-LAX',
+1863 silly get     'x-cache': 'HIT',
+1863 silly get     'x-cache-hits': '1',
+1863 silly get     'x-timer': 'S1437673558.383715,VS0,VE308',
+1863 silly get     vary: 'Accept' } ]
+1864 verbose get saving grunt-express-server to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-express-server\.cache.json
+1865 http 200 https://registry.npmjs.org/grunt-angular-templates
+1866 silly get cb [ 200,
+1866 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1866 silly get     etag: '"DRVG4IED7GB25LEAW51LNGORN"',
+1866 silly get     'content-type': 'application/json',
+1866 silly get     'cache-control': 'max-age=60',
+1866 silly get     'content-length': '65898',
+1866 silly get     'accept-ranges': 'bytes',
+1866 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1866 silly get     via: '1.1 varnish',
+1866 silly get     age: '0',
+1866 silly get     connection: 'keep-alive',
+1866 silly get     'x-served-by': 'cache-lax1427-LAX',
+1866 silly get     'x-cache': 'HIT',
+1866 silly get     'x-cache-hits': '1',
+1866 silly get     'x-timer': 'S1437673558.508772,VS0,VE83',
+1866 silly get     vary: 'Accept' } ]
+1867 verbose get saving grunt-angular-templates to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-angular-templates\.cache.json
+1868 info retry fetch attempt 1 at 10:46:00 AM
+1869 info attempt registry request try #1 at 10:46:00 AM
+1870 http fetch GET https://registry.npmjs.org/fs-finder/-/fs-finder-1.8.1.tgz
+1871 info retry fetch attempt 1 at 10:46:00 AM
+1872 info attempt registry request try #1 at 10:46:00 AM
+1873 http fetch GET https://registry.npmjs.org/grunt-docker/-/grunt-docker-0.0.10.tgz
+1874 info retry fetch attempt 1 at 10:46:00 AM
+1875 info attempt registry request try #1 at 10:46:00 AM
+1876 http fetch GET https://registry.npmjs.org/jade-browser-middleware/-/jade-browser-middleware-0.3.3.tgz
+1877 http 200 https://registry.npmjs.org/winston
+1878 silly get cb [ 200,
+1878 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1878 silly get     etag: '"8H1B5Y8U8K8VS6UURYYCFHRP7"',
+1878 silly get     'content-type': 'application/json',
+1878 silly get     'cache-control': 'max-age=60',
+1878 silly get     'content-length': '80448',
+1878 silly get     'accept-ranges': 'bytes',
+1878 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1878 silly get     via: '1.1 varnish',
+1878 silly get     age: '14',
+1878 silly get     connection: 'keep-alive',
+1878 silly get     'x-served-by': 'cache-lax1429-LAX',
+1878 silly get     'x-cache': 'HIT',
+1878 silly get     'x-cache-hits': '1',
+1878 silly get     'x-timer': 'S1437673558.301260,VS0,VE0',
+1878 silly get     vary: 'Accept' } ]
+1879 verbose get saving winston to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\winston\.cache.json
+1880 http 200 https://registry.npmjs.org/grunt-karma
+1881 silly get cb [ 200,
+1881 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1881 silly get     etag: '"BSH5IB7CB2VWYVVYV99RBHGH8"',
+1881 silly get     'content-type': 'application/json',
+1881 silly get     'cache-control': 'max-age=60',
+1881 silly get     'content-length': '57091',
+1881 silly get     'accept-ranges': 'bytes',
+1881 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1881 silly get     via: '1.1 varnish',
+1881 silly get     age: '17',
+1881 silly get     connection: 'keep-alive',
+1881 silly get     'x-served-by': 'cache-lax1425-LAX',
+1881 silly get     'x-cache': 'HIT',
+1881 silly get     'x-cache-hits': '1',
+1881 silly get     'x-timer': 'S1437673558.425479,VS0,VE0',
+1881 silly get     vary: 'Accept' } ]
+1882 verbose get saving grunt-karma to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-karma\.cache.json
+1883 http 200 https://registry.npmjs.org/grunt-contrib-stylus
+1884 silly get cb [ 200,
+1884 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1884 silly get     etag: '"BKJ7WJIQETBQI2M8WNFE52MU1"',
+1884 silly get     'content-type': 'application/json',
+1884 silly get     'cache-control': 'max-age=60',
+1884 silly get     'content-length': '60171',
+1884 silly get     'accept-ranges': 'bytes',
+1884 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1884 silly get     via: '1.1 varnish',
+1884 silly get     age: '0',
+1884 silly get     connection: 'keep-alive',
+1884 silly get     'x-served-by': 'cache-lax1422-LAX',
+1884 silly get     'x-cache': 'HIT',
+1884 silly get     'x-cache-hits': '1',
+1884 silly get     'x-timer': 'S1437673558.798123,VS0,VE46',
+1884 silly get     vary: 'Accept' } ]
+1885 verbose get saving grunt-contrib-stylus to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-stylus\.cache.json
+1886 http 200 https://registry.npmjs.org/should
+1887 silly get cb [ 200,
+1887 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1887 silly get     etag: '"3BDCL9X5LFL5N3RHFSYX53UWF"',
+1887 silly get     'content-type': 'application/json',
+1887 silly get     'cache-control': 'max-age=60',
+1887 silly get     'content-length': '101785',
+1887 silly get     'accept-ranges': 'bytes',
+1887 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1887 silly get     via: '1.1 varnish',
+1887 silly get     age: '0',
+1887 silly get     connection: 'keep-alive',
+1887 silly get     'x-served-by': 'cache-lax1431-LAX',
+1887 silly get     'x-cache': 'HIT',
+1887 silly get     'x-cache-hits': '1',
+1887 silly get     'x-timer': 'S1437673558.520242,VS0,VE77',
+1887 silly get     vary: 'Accept' } ]
+1888 verbose get saving should to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\should\.cache.json
+1889 http 200 https://registry.npmjs.org/grunt-contrib-watch
+1890 silly get cb [ 200,
+1890 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+1890 silly get     etag: '"9TX3DLJNSOXVF22LQ67BZ0SDX"',
+1890 silly get     'content-type': 'application/json',
+1890 silly get     'cache-control': 'max-age=60',
+1890 silly get     'content-length': '58779',
+1890 silly get     'accept-ranges': 'bytes',
+1890 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+1890 silly get     via: '1.1 varnish',
+1890 silly get     age: '55',
+1890 silly get     connection: 'keep-alive',
+1890 silly get     'x-served-by': 'cache-lax1425-LAX',
+1890 silly get     'x-cache': 'HIT',
+1890 silly get     'x-cache-hits': '1',
+1890 silly get     'x-timer': 'S1437673558.822967,VS0,VE0',
+1890 silly get     vary: 'Accept' } ]
+1891 verbose get saving grunt-contrib-watch to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-watch\.cache.json
+1892 silly addNameRange number 2 { name: 'express', range: '>=4.0.0 <4.1.0', hasData: true }
+1893 silly addNameRange versions [ 'express',
+1893 silly addNameRange   [ '0.14.0',
+1893 silly addNameRange     '0.14.1',
+1893 silly addNameRange     '1.0.0',
+1893 silly addNameRange     '1.0.1',
+1893 silly addNameRange     '1.0.2',
+1893 silly addNameRange     '1.0.3',
+1893 silly addNameRange     '1.0.4',
+1893 silly addNameRange     '1.0.5',
+1893 silly addNameRange     '1.0.6',
+1893 silly addNameRange     '1.0.7',
+1893 silly addNameRange     '1.0.8',
+1893 silly addNameRange     '2.0.0',
+1893 silly addNameRange     '2.1.0',
+1893 silly addNameRange     '2.1.1',
+1893 silly addNameRange     '2.2.0',
+1893 silly addNameRange     '2.2.1',
+1893 silly addNameRange     '2.2.2',
+1893 silly addNameRange     '2.3.0',
+1893 silly addNameRange     '2.3.1',
+1893 silly addNameRange     '2.3.2',
+1893 silly addNameRange     '2.3.3',
+1893 silly addNameRange     '2.3.4',
+1893 silly addNameRange     '2.3.5',
+1893 silly addNameRange     '2.3.6',
+1893 silly addNameRange     '2.3.7',
+1893 silly addNameRange     '2.3.8',
+1893 silly addNameRange     '2.3.9',
+1893 silly addNameRange     '2.3.10',
+1893 silly addNameRange     '2.3.11',
+1893 silly addNameRange     '2.3.12',
+1893 silly addNameRange     '2.4.0',
+1893 silly addNameRange     '2.4.1',
+1893 silly addNameRange     '2.4.2',
+1893 silly addNameRange     '2.4.3',
+1893 silly addNameRange     '2.4.4',
+1893 silly addNameRange     '2.4.5',
+1893 silly addNameRange     '2.4.6',
+1893 silly addNameRange     '2.4.7',
+1893 silly addNameRange     '2.5.0',
+1893 silly addNameRange     '2.5.1',
+1893 silly addNameRange     '2.5.2',
+1893 silly addNameRange     '2.5.3',
+1893 silly addNameRange     '2.5.4',
+1893 silly addNameRange     '2.5.5',
+1893 silly addNameRange     '2.5.6',
+1893 silly addNameRange     '2.5.7',
+1893 silly addNameRange     '2.5.8',
+1893 silly addNameRange     '2.5.9',
+1893 silly addNameRange     '2.5.10',
+1893 silly addNameRange     '2.5.11',
+1893 silly addNameRange     '3.0.0',
+1893 silly addNameRange     '3.0.1',
+1893 silly addNameRange     '3.0.2',
+1893 silly addNameRange     '3.0.3',
+1893 silly addNameRange     '3.0.4',
+1893 silly addNameRange     '3.0.5',
+1893 silly addNameRange     '3.0.6',
+1893 silly addNameRange     '3.1.0',
+1893 silly addNameRange     '3.1.1',
+1893 silly addNameRange     '3.1.2',
+1893 silly addNameRange     '3.2.0',
+1893 silly addNameRange     '3.2.1',
+1893 silly addNameRange     '3.2.2',
+1893 silly addNameRange     '3.2.3',
+1893 silly addNameRange     '3.2.4',
+1893 silly addNameRange     '3.2.5',
+1893 silly addNameRange     '3.2.6',
+1893 silly addNameRange     '3.3.0',
+1893 silly addNameRange     '3.3.1',
+1893 silly addNameRange     '3.3.2',
+1893 silly addNameRange     '3.3.3',
+1893 silly addNameRange     '3.3.4',
+1893 silly addNameRange     '3.3.5',
+1893 silly addNameRange     '3.3.6',
+1893 silly addNameRange     '1.0.0-beta',
+1893 silly addNameRange     '1.0.0-beta2',
+1893 silly addNameRange     '1.0.0-rc',
+1893 silly addNameRange     '1.0.0-rc2',
+1893 silly addNameRange     '1.0.0-rc3',
+1893 silly addNameRange     '1.0.0-rc4',
+1893 silly addNameRange     '2.0.0-beta',
+1893 silly addNameRange     '2.0.0-beta2',
+1893 silly addNameRange     '2.0.0-beta3',
+1893 silly addNameRange     '2.0.0-rc',
+1893 silly addNameRange     '2.0.0-rc2',
+1893 silly addNameRange     '2.0.0-rc3',
+1893 silly addNameRange     '3.0.0-alpha1',
+1893 silly addNameRange     '3.0.0-alpha2',
+1893 silly addNameRange     '3.0.0-alpha3',
+1893 silly addNameRange     '3.0.0-alpha4',
+1893 silly addNameRange     '3.0.0-alpha5',
+1893 silly addNameRange     '3.0.0-beta1',
+1893 silly addNameRange     '3.0.0-beta2',
+1893 silly addNameRange     '3.0.0-beta3',
+1893 silly addNameRange     '3.0.0-beta4',
+1893 silly addNameRange     '3.0.0-beta6',
+1893 silly addNameRange     '3.0.0-beta7',
+1893 silly addNameRange     '3.0.0-rc1',
+1893 silly addNameRange     '3.0.0-rc2',
+1893 silly addNameRange     '3.0.0-rc3',
+1893 silly addNameRange     '3.0.0-rc4',
+1893 silly addNameRange     '3.0.0-rc5',
+1893 silly addNameRange     '3.3.7',
+1893 silly addNameRange     '3.3.8',
+1893 silly addNameRange     '3.4.0',
+1893 silly addNameRange     '3.4.1',
+1893 silly addNameRange     '3.4.2',
+1893 silly addNameRange     '3.4.3',
+1893 silly addNameRange     '3.4.4',
+1893 silly addNameRange     '3.4.5',
+1893 silly addNameRange     '3.4.6',
+1893 silly addNameRange     '3.4.7',
+1893 silly addNameRange     '3.4.8',
+1893 silly addNameRange     '4.0.0-rc1',
+1893 silly addNameRange     '4.0.0-rc2',
+1893 silly addNameRange     '3.5.0',
+1893 silly addNameRange     '4.0.0-rc3',
+1893 silly addNameRange     '4.0.0-rc4',
+1893 silly addNameRange     '3.5.1',
+1893 silly addNameRange     '4.0.0',
+1893 silly addNameRange     '3.5.2',
+1893 silly addNameRange     '4.1.0',
+1893 silly addNameRange     '4.1.1',
+1893 silly addNameRange     '3.5.3',
+1893 silly addNameRange     '4.1.2',
+1893 silly addNameRange     '3.6.0',
+1893 silly addNameRange     '4.2.0',
+1893 silly addNameRange     '3.7.0',
+1893 silly addNameRange     '3.8.0',
+1893 silly addNameRange     '4.3.0',
+1893 silly addNameRange     '4.3.1',
+1893 silly addNameRange     '3.8.1',
+1893 silly addNameRange     '4.3.2',
+1893 silly addNameRange     '3.9.0',
+1893 silly addNameRange     '4.4.0',
+1893 silly addNameRange     '4.4.1',
+1893 silly addNameRange     '3.10.0',
+1893 silly addNameRange     '3.10.1',
+1893 silly addNameRange     '3.10.2',
+1893 silly addNameRange     '3.10.3',
+1893 silly addNameRange     '3.10.4',
+1893 silly addNameRange     '4.4.2',
+1893 silly addNameRange     '3.10.5',
+1893 silly addNameRange     '4.4.3',
+1893 silly addNameRange     '3.11.0',
+1893 silly addNameRange     '4.4.4',
+1893 silly addNameRange     '3.12.0',
+1893 silly addNameRange     '3.12.1',
+1893 silly addNameRange     '4.4.5',
+1893 silly addNameRange     '3.13.0',
+1893 silly addNameRange     '4.5.0',
+1893 silly addNameRange     '4.5.1',
+1893 silly addNameRange     '3.14.0',
+1893 silly addNameRange     '4.6.0',
+1893 silly addNameRange     '4.6.1',
+1893 silly addNameRange     '3.15.0',
+1893 silly addNameRange     '4.7.0',
+1893 silly addNameRange     '3.15.1',
+1893 silly addNameRange     '4.7.1',
+1893 silly addNameRange     '3.15.2',
+1893 silly addNameRange     '4.7.2',
+1893 silly addNameRange     '4.7.3',
+1893 silly addNameRange     '3.15.3',
+1893 silly addNameRange     '4.7.4',
+1893 silly addNameRange     '3.16.0',
+1893 silly addNameRange     '4.8.0',
+1893 silly addNameRange     '3.16.1',
+1893 silly addNameRange     '4.8.1',
+1893 silly addNameRange     '3.16.2',
+1893 silly addNameRange     '4.8.2',
+1893 silly addNameRange     '3.16.3',
+1893 silly addNameRange     '3.16.4',
+1893 silly addNameRange     '4.8.3',
+1893 silly addNameRange     '3.16.5',
+1893 silly addNameRange     '3.16.6',
+1893 silly addNameRange     '4.8.4',
+1893 silly addNameRange     '3.16.7',
+1893 silly addNameRange     '4.8.5',
+1893 silly addNameRange     '3.16.8',
+1893 silly addNameRange     '4.8.6',
+1893 silly addNameRange     '3.16.9',
+1893 silly addNameRange     '4.8.7',
+1893 silly addNameRange     '3.16.10',
+1893 silly addNameRange     '4.8.8',
+1893 silly addNameRange     '3.17.0',
+1893 silly addNameRange     '3.17.1',
+1893 silly addNameRange     '4.9.0',
+1893 silly addNameRange     '3.17.2',
+1893 silly addNameRange     '4.9.1',
+1893 silly addNameRange     '4.9.2',
+1893 silly addNameRange     '3.17.3',
+1893 silly addNameRange     '4.9.3',
+1893 silly addNameRange     '3.17.4',
+1893 silly addNameRange     '4.9.4',
+1893 silly addNameRange     '3.17.5',
+1893 silly addNameRange     '4.9.5',
+1893 silly addNameRange     '3.17.6',
+1893 silly addNameRange     '3.17.7',
+1893 silly addNameRange     '4.9.6',
+1893 silly addNameRange     '4.9.7',
+1893 silly addNameRange     '3.17.8',
+1893 silly addNameRange     '4.9.8',
+1893 silly addNameRange     '3.18.0',
+1893 silly addNameRange     '3.18.1',
+1893 silly addNameRange     '4.10.0',
+1893 silly addNameRange     '3.18.2',
+1893 silly addNameRange     '4.10.1',
+1893 silly addNameRange     '5.0.0-alpha.1',
+1893 silly addNameRange     '3.18.3',
+1893 silly addNameRange     '4.10.2',
+1893 silly addNameRange     '3.18.4',
+1893 silly addNameRange     '4.10.3',
+1893 silly addNameRange     '4.10.4',
+1893 silly addNameRange     '4.10.5',
+1893 silly addNameRange     '3.18.5',
+1893 silly addNameRange     '3.18.6',
+1893 silly addNameRange     '4.10.6',
+1893 silly addNameRange     '4.10.7',
+1893 silly addNameRange     '3.19.0',
+1893 silly addNameRange     '4.10.8',
+1893 silly addNameRange     '4.11.0',
+1893 silly addNameRange     '3.19.1',
+1893 silly addNameRange     '4.11.1',
+1893 silly addNameRange     '3.19.2',
+1893 silly addNameRange     '4.11.2',
+1893 silly addNameRange     '3.20.0',
+1893 silly addNameRange     '4.12.0',
+1893 silly addNameRange     '3.20.1',
+1893 silly addNameRange     '4.12.1',
+1893 silly addNameRange     '4.12.2',
+1893 silly addNameRange     '3.20.2',
+1893 silly addNameRange     '4.12.3',
+1893 silly addNameRange     '3.20.3',
+1893 silly addNameRange     '4.12.4',
+1893 silly addNameRange     '3.21.0',
+1893 silly addNameRange     '4.13.0',
+1893 silly addNameRange     '3.21.1',
+1893 silly addNameRange     '4.13.1',
+1893 silly addNameRange     '5.0.0-alpha.2' ] ]
+1894 verbose addNamed express@4.0.0
+1895 silly addNamed semver.valid 4.0.0
+1896 silly addNamed semver.validRange 4.0.0
+1897 silly addNameRange number 2 { name: 'express-session',
+1897 silly addNameRange   range: '>=1.0.2 <1.1.0',
+1897 silly addNameRange   hasData: true }
+1898 silly addNameRange versions [ 'express-session',
+1898 silly addNameRange   [ '1.0.0',
+1898 silly addNameRange     '1.0.1',
+1898 silly addNameRange     '1.0.2',
+1898 silly addNameRange     '1.0.3',
+1898 silly addNameRange     '1.0.4',
+1898 silly addNameRange     '1.1.0',
+1898 silly addNameRange     '1.2.0',
+1898 silly addNameRange     '1.2.1',
+1898 silly addNameRange     '1.3.0',
+1898 silly addNameRange     '1.3.1',
+1898 silly addNameRange     '1.4.0',
+1898 silly addNameRange     '1.5.0',
+1898 silly addNameRange     '1.5.1',
+1898 silly addNameRange     '1.5.2',
+1898 silly addNameRange     '1.6.0',
+1898 silly addNameRange     '1.6.1',
+1898 silly addNameRange     '1.6.2',
+1898 silly addNameRange     '1.6.3',
+1898 silly addNameRange     '1.6.4',
+1898 silly addNameRange     '1.6.5',
+1898 silly addNameRange     '1.7.0',
+1898 silly addNameRange     '1.7.1',
+1898 silly addNameRange     '1.7.2',
+1898 silly addNameRange     '1.7.3',
+1898 silly addNameRange     '1.7.4',
+1898 silly addNameRange     '1.7.5',
+1898 silly addNameRange     '1.7.6',
+1898 silly addNameRange     '1.8.0',
+1898 silly addNameRange     '1.8.1',
+1898 silly addNameRange     '1.8.2',
+1898 silly addNameRange     '1.9.0',
+1898 silly addNameRange     '1.9.1',
+1898 silly addNameRange     '1.9.2',
+1898 silly addNameRange     '1.9.3',
+1898 silly addNameRange     '1.10.0',
+1898 silly addNameRange     '1.10.1',
+1898 silly addNameRange     '1.10.2',
+1898 silly addNameRange     '1.10.3',
+1898 silly addNameRange     '1.10.4',
+1898 silly addNameRange     '1.11.0',
+1898 silly addNameRange     '1.11.1',
+1898 silly addNameRange     '1.11.2',
+1898 silly addNameRange     '1.11.3' ] ]
+1899 verbose addNamed express-session@1.0.4
+1900 silly addNamed semver.valid 1.0.4
+1901 silly addNamed semver.validRange 1.0.4
+1902 silly addNameRange number 2 { name: 'jsonwebtoken', range: '>=0.3.0 <0.4.0', hasData: true }
+1903 silly addNameRange versions [ 'jsonwebtoken',
+1903 silly addNameRange   [ '0.1.0',
+1903 silly addNameRange     '0.2.0',
+1903 silly addNameRange     '0.3.0',
+1903 silly addNameRange     '0.4.0',
+1903 silly addNameRange     '0.4.1',
+1903 silly addNameRange     '1.0.0',
+1903 silly addNameRange     '1.0.2',
+1903 silly addNameRange     '1.1.0',
+1903 silly addNameRange     '1.1.1',
+1903 silly addNameRange     '1.1.2',
+1903 silly addNameRange     '1.2.0',
+1903 silly addNameRange     '1.3.0',
+1903 silly addNameRange     '2.0.0',
+1903 silly addNameRange     '3.0.0',
+1903 silly addNameRange     '3.1.0',
+1903 silly addNameRange     '3.1.1',
+1903 silly addNameRange     '3.2.0',
+1903 silly addNameRange     '3.2.1',
+1903 silly addNameRange     '3.2.2',
+1903 silly addNameRange     '4.0.0',
+1903 silly addNameRange     '4.1.0',
+1903 silly addNameRange     '4.2.0',
+1903 silly addNameRange     '4.2.1',
+1903 silly addNameRange     '4.2.2',
+1903 silly addNameRange     '5.0.0',
+1903 silly addNameRange     '5.0.1',
+1903 silly addNameRange     '5.0.2',
+1903 silly addNameRange     '5.0.3',
+1903 silly addNameRange     '5.0.4' ] ]
+1904 verbose addNamed jsonwebtoken@0.3.0
+1905 silly addNamed semver.valid 0.3.0
+1906 silly addNamed semver.validRange 0.3.0
+1907 warn deprecated jsonwebtoken@0.3.0: Critical vulnerability fix in v5.0.0. See https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/
+1908 silly addNameRange number 2 { name: 'errorhandler', range: '>=1.0.0 <1.1.0', hasData: true }
+1909 silly addNameRange versions [ 'errorhandler',
+1909 silly addNameRange   [ '1.0.0',
+1909 silly addNameRange     '1.0.1',
+1909 silly addNameRange     '1.0.2',
+1909 silly addNameRange     '1.1.0',
+1909 silly addNameRange     '1.1.1',
+1909 silly addNameRange     '1.2.0',
+1909 silly addNameRange     '1.2.1',
+1909 silly addNameRange     '1.2.2',
+1909 silly addNameRange     '1.2.3',
+1909 silly addNameRange     '1.3.0',
+1909 silly addNameRange     '1.3.1',
+1909 silly addNameRange     '1.2.4',
+1909 silly addNameRange     '1.3.2',
+1909 silly addNameRange     '1.3.3',
+1909 silly addNameRange     '1.3.4',
+1909 silly addNameRange     '1.3.5',
+1909 silly addNameRange     '1.3.6',
+1909 silly addNameRange     '1.4.0',
+1909 silly addNameRange     '1.4.1' ] ]
+1910 verbose addNamed errorhandler@1.0.2
+1911 silly addNamed semver.valid 1.0.2
+1912 silly addNamed semver.validRange 1.0.2
+1913 silly addNameRange number 2 { name: 'method-override',
+1913 silly addNameRange   range: '>=1.0.0 <1.1.0',
+1913 silly addNameRange   hasData: true }
+1914 silly addNameRange versions [ 'method-override',
+1914 silly addNameRange   [ '1.0.0',
+1914 silly addNameRange     '1.0.1',
+1914 silly addNameRange     '1.0.2',
+1914 silly addNameRange     '2.0.0',
+1914 silly addNameRange     '2.0.1',
+1914 silly addNameRange     '2.0.2',
+1914 silly addNameRange     '2.1.0',
+1914 silly addNameRange     '2.1.1',
+1914 silly addNameRange     '2.1.2',
+1914 silly addNameRange     '2.1.3',
+1914 silly addNameRange     '2.2.0',
+1914 silly addNameRange     '2.3.0',
+1914 silly addNameRange     '2.3.1',
+1914 silly addNameRange     '2.3.2',
+1914 silly addNameRange     '2.3.3',
+1914 silly addNameRange     '2.3.4' ] ]
+1915 verbose addNamed method-override@1.0.2
+1916 silly addNamed semver.valid 1.0.2
+1917 silly addNamed semver.validRange 1.0.2
+1918 silly addNameRange number 2 { name: 'formidable', range: '>=1.0.17 <2.0.0', hasData: true }
+1919 silly addNameRange versions [ 'formidable',
+1919 silly addNameRange   [ '0.3.0',
+1919 silly addNameRange     '0.4.0',
+1919 silly addNameRange     '0.5.0',
+1919 silly addNameRange     '0.6.0',
+1919 silly addNameRange     '0.7.0',
+1919 silly addNameRange     '0.8.0',
+1919 silly addNameRange     '0.9.0',
+1919 silly addNameRange     '0.9.1',
+1919 silly addNameRange     '0.9.2',
+1919 silly addNameRange     '0.9.3',
+1919 silly addNameRange     '0.9.4',
+1919 silly addNameRange     '0.9.5',
+1919 silly addNameRange     '0.9.6',
+1919 silly addNameRange     '0.9.7',
+1919 silly addNameRange     '0.9.8',
+1919 silly addNameRange     '0.9.9',
+1919 silly addNameRange     '0.9.10',
+1919 silly addNameRange     '0.9.11',
+1919 silly addNameRange     '1.0.0',
+1919 silly addNameRange     '1.0.1',
+1919 silly addNameRange     '1.0.2',
+1919 silly addNameRange     '1.0.3',
+1919 silly addNameRange     '1.0.4',
+1919 silly addNameRange     '1.0.5',
+1919 silly addNameRange     '1.0.6',
+1919 silly addNameRange     '1.0.7',
+1919 silly addNameRange     '1.0.8',
+1919 silly addNameRange     '1.0.9',
+1919 silly addNameRange     '1.0.10',
+1919 silly addNameRange     '1.0.11',
+1919 silly addNameRange     '1.0.12',
+1919 silly addNameRange     '1.0.13',
+1919 silly addNameRange     '1.0.14',
+1919 silly addNameRange     '1.0.15',
+1919 silly addNameRange     '1.0.16',
+1919 silly addNameRange     '1.0.17' ] ]
+1920 verbose addNamed formidable@1.0.17
+1921 silly addNamed semver.valid 1.0.17
+1922 silly addNamed semver.validRange 1.0.17
+1923 silly addNameRange number 2 { name: 'lodash', range: '>=2.4.1 <2.5.0', hasData: true }
+1924 silly addNameRange versions [ 'lodash',
+1924 silly addNameRange   [ '0.1.0',
+1924 silly addNameRange     '0.2.0',
+1924 silly addNameRange     '0.2.1',
+1924 silly addNameRange     '0.2.2',
+1924 silly addNameRange     '0.3.0',
+1924 silly addNameRange     '0.3.1',
+1924 silly addNameRange     '0.3.2',
+1924 silly addNameRange     '0.4.0',
+1924 silly addNameRange     '0.4.1',
+1924 silly addNameRange     '0.4.2',
+1924 silly addNameRange     '0.5.0-rc.1',
+1924 silly addNameRange     '0.5.0',
+1924 silly addNameRange     '0.5.1',
+1924 silly addNameRange     '0.5.2',
+1924 silly addNameRange     '0.6.0',
+1924 silly addNameRange     '0.6.1',
+1924 silly addNameRange     '0.7.0',
+1924 silly addNameRange     '0.8.0',
+1924 silly addNameRange     '0.8.1',
+1924 silly addNameRange     '0.8.2',
+1924 silly addNameRange     '0.9.0',
+1924 silly addNameRange     '0.9.1',
+1924 silly addNameRange     '0.9.2',
+1924 silly addNameRange     '0.10.0',
+1924 silly addNameRange     '1.0.0-rc.1',
+1924 silly addNameRange     '1.0.0-rc.2',
+1924 silly addNameRange     '1.0.0-rc.3',
+1924 silly addNameRange     '1.0.0',
+1924 silly addNameRange     '1.0.1',
+1924 silly addNameRange     '1.1.0',
+1924 silly addNameRange     '1.1.1',
+1924 silly addNameRange     '1.2.0',
+1924 silly addNameRange     '1.2.1',
+1924 silly addNameRange     '1.3.0',
+1924 silly addNameRange     '1.3.1',
+1924 silly addNameRange     '2.0.0',
+1924 silly addNameRange     '2.1.0',
+1924 silly addNameRange     '2.2.0',
+1924 silly addNameRange     '2.2.1',
+1924 silly addNameRange     '2.3.0',
+1924 silly addNameRange     '2.4.0',
+1924 silly addNameRange     '2.4.1',
+1924 silly addNameRange     '3.0.0',
+1924 silly addNameRange     '3.0.1',
+1924 silly addNameRange     '3.1.0',
+1924 silly addNameRange     '3.2.0',
+1924 silly addNameRange     '3.3.0',
+1924 silly addNameRange     '3.3.1',
+1924 silly addNameRange     '3.4.0',
+1924 silly addNameRange     '3.5.0',
+1924 silly addNameRange     '3.6.0',
+1924 silly addNameRange     '1.0.2',
+1924 silly addNameRange     '3.7.0',
+1924 silly addNameRange     '2.4.2',
+1924 silly addNameRange     '3.8.0',
+1924 silly addNameRange     '3.9.0',
+1924 silly addNameRange     '3.9.1',
+1924 silly addNameRange     '3.9.2',
+1924 silly addNameRange     '3.9.3',
+1924 silly addNameRange     '3.10.0' ] ]
+1925 verbose addNamed lodash@2.4.2
+1926 silly addNamed semver.valid 2.4.2
+1927 silly addNamed semver.validRange 2.4.2
+1928 silly addNameRange number 2 { name: 'serve-favicon', range: '>=2.0.1 <2.1.0', hasData: true }
+1929 silly addNameRange versions [ 'serve-favicon',
+1929 silly addNameRange   [ '2.0.0',
+1929 silly addNameRange     '2.0.1',
+1929 silly addNameRange     '2.1.0',
+1929 silly addNameRange     '2.1.1',
+1929 silly addNameRange     '2.1.2',
+1929 silly addNameRange     '2.1.3',
+1929 silly addNameRange     '2.1.4',
+1929 silly addNameRange     '2.1.5',
+1929 silly addNameRange     '2.1.6',
+1929 silly addNameRange     '2.1.7',
+1929 silly addNameRange     '2.2.0',
+1929 silly addNameRange     '2.2.1',
+1929 silly addNameRange     '2.3.0' ] ]
+1930 verbose addNamed serve-favicon@2.0.1
+1931 silly addNamed semver.valid 2.0.1
+1932 silly addNamed semver.validRange 2.0.1
+1933 silly addNameRange number 2 { name: 'passport-local',
+1933 silly addNameRange   range: '>=0.1.6 <0.2.0',
+1933 silly addNameRange   hasData: true }
+1934 silly addNameRange versions [ 'passport-local',
+1934 silly addNameRange   [ '0.1.0',
+1934 silly addNameRange     '0.1.1',
+1934 silly addNameRange     '0.1.2',
+1934 silly addNameRange     '0.1.3',
+1934 silly addNameRange     '0.1.4',
+1934 silly addNameRange     '0.1.5',
+1934 silly addNameRange     '0.1.6',
+1934 silly addNameRange     '1.0.0' ] ]
+1935 verbose addNamed passport-local@0.1.6
+1936 silly addNamed semver.valid 0.1.6
+1937 silly addNamed semver.validRange 0.1.6
+1938 silly addNameRange number 2 { name: 'passport', range: '>=0.2.0 <0.3.0', hasData: true }
+1939 silly addNameRange versions [ 'passport',
+1939 silly addNameRange   [ '0.1.0',
+1939 silly addNameRange     '0.1.1',
+1939 silly addNameRange     '0.1.2',
+1939 silly addNameRange     '0.1.3',
+1939 silly addNameRange     '0.1.4',
+1939 silly addNameRange     '0.1.5',
+1939 silly addNameRange     '0.1.6',
+1939 silly addNameRange     '0.1.7',
+1939 silly addNameRange     '0.1.8',
+1939 silly addNameRange     '0.1.9',
+1939 silly addNameRange     '0.1.10',
+1939 silly addNameRange     '0.1.11',
+1939 silly addNameRange     '0.1.12',
+1939 silly addNameRange     '0.1.13',
+1939 silly addNameRange     '0.1.14',
+1939 silly addNameRange     '0.1.15',
+1939 silly addNameRange     '0.1.16',
+1939 silly addNameRange     '0.1.17',
+1939 silly addNameRange     '0.1.18',
+1939 silly addNameRange     '0.2.0',
+1939 silly addNameRange     '0.2.1',
+1939 silly addNameRange     '0.2.2' ] ]
+1940 verbose addNamed passport@0.2.2
+1941 silly addNamed semver.valid 0.2.2
+1942 silly addNamed semver.validRange 0.2.2
+1943 silly addNameRange number 2 { name: 'express-jwt', range: '>=0.1.3 <0.2.0', hasData: true }
+1944 silly addNameRange versions [ 'express-jwt',
+1944 silly addNameRange   [ '0.1.0',
+1944 silly addNameRange     '0.1.1',
+1944 silly addNameRange     '0.1.2',
+1944 silly addNameRange     '0.2.0',
+1944 silly addNameRange     '0.1.3',
+1944 silly addNameRange     '0.1.4',
+1944 silly addNameRange     '0.2.1',
+1944 silly addNameRange     '0.2.2',
+1944 silly addNameRange     '0.3.0',
+1944 silly addNameRange     '0.3.1',
+1944 silly addNameRange     '0.3.2',
+1944 silly addNameRange     '0.4.0',
+1944 silly addNameRange     '0.5.0',
+1944 silly addNameRange     '0.5.1',
+1944 silly addNameRange     '0.6.1',
+1944 silly addNameRange     '0.6.2',
+1944 silly addNameRange     '1.0.0',
+1944 silly addNameRange     '1.1.0',
+1944 silly addNameRange     '1.2.0',
+1944 silly addNameRange     '1.3.0',
+1944 silly addNameRange     '1.3.1',
+1944 silly addNameRange     '1.4.0',
+1944 silly addNameRange     '2.0.0',
+1944 silly addNameRange     '2.0.1',
+1944 silly addNameRange     '2.1.0',
+1944 silly addNameRange     '3.0.0',
+1944 silly addNameRange     '3.0.1' ] ]
+1945 verbose addNamed express-jwt@0.1.4
+1946 silly addNamed semver.valid 0.1.4
+1947 silly addNamed semver.validRange 0.1.4
+1948 silly addNameRange number 2 { name: 'multer', range: '>=0.1.8 <0.2.0', hasData: true }
+1949 silly addNameRange versions [ 'multer',
+1949 silly addNameRange   [ '0.0.1',
+1949 silly addNameRange     '0.0.2',
+1949 silly addNameRange     '0.0.3',
+1949 silly addNameRange     '0.0.4',
+1949 silly addNameRange     '0.0.5',
+1949 silly addNameRange     '0.0.6',
+1949 silly addNameRange     '0.0.7',
+1949 silly addNameRange     '0.1.0',
+1949 silly addNameRange     '0.1.1',
+1949 silly addNameRange     '0.1.2',
+1949 silly addNameRange     '0.1.3',
+1949 silly addNameRange     '0.1.4',
+1949 silly addNameRange     '0.1.6',
+1949 silly addNameRange     '0.1.7',
+1949 silly addNameRange     '0.1.8',
+1949 silly addNameRange     '1.0.0',
+1949 silly addNameRange     '1.0.1' ] ]
+1950 verbose addNamed multer@0.1.8
+1951 silly addNamed semver.valid 0.1.8
+1952 silly addNamed semver.validRange 0.1.8
+1953 silly addNameRange number 2 { name: 'mongoose', range: '>=3.8.8 <3.9.0', hasData: true }
+1954 silly addNameRange versions [ 'mongoose',
+1954 silly addNameRange   [ '0.0.1',
+1954 silly addNameRange     '0.0.2',
+1954 silly addNameRange     '0.0.3',
+1954 silly addNameRange     '0.0.4',
+1954 silly addNameRange     '0.0.5',
+1954 silly addNameRange     '1.0.0',
+1954 silly addNameRange     '1.0.1',
+1954 silly addNameRange     '1.0.2',
+1954 silly addNameRange     '0.0.6',
+1954 silly addNameRange     '1.0.3',
+1954 silly addNameRange     '1.0.4',
+1954 silly addNameRange     '1.0.5',
+1954 silly addNameRange     '1.0.6',
+1954 silly addNameRange     '1.0.7',
+1954 silly addNameRange     '1.0.8',
+1954 silly addNameRange     '1.0.10',
+1954 silly addNameRange     '1.0.11',
+1954 silly addNameRange     '1.0.12',
+1954 silly addNameRange     '1.0.13',
+1954 silly addNameRange     '1.0.14',
+1954 silly addNameRange     '1.0.15',
+1954 silly addNameRange     '1.0.16',
+1954 silly addNameRange     '1.1.0',
+1954 silly addNameRange     '1.1.1',
+1954 silly addNameRange     '1.1.2',
+1954 silly addNameRange     '1.1.3',
+1954 silly addNameRange     '1.1.4',
+1954 silly addNameRange     '1.1.5',
+1954 silly addNameRange     '1.1.6',
+1954 silly addNameRange     '1.1.7',
+1954 silly addNameRange     '1.1.8',
+1954 silly addNameRange     '1.1.9',
+1954 silly addNameRange     '1.1.10',
+1954 silly addNameRange     '1.1.11',
+1954 silly addNameRange     '1.1.12',
+1954 silly addNameRange     '1.1.13',
+1954 silly addNameRange     '1.1.14',
+1954 silly addNameRange     '1.1.15',
+1954 silly addNameRange     '1.1.16',
+1954 silly addNameRange     '1.1.17',
+1954 silly addNameRange     '1.1.18',
+1954 silly addNameRange     '1.1.19',
+1954 silly addNameRange     '1.1.20',
+1954 silly addNameRange     '1.1.21',
+1954 silly addNameRange     '1.1.22',
+1954 silly addNameRange     '1.1.23',
+1954 silly addNameRange     '1.1.24',
+1954 silly addNameRange     '1.1.25',
+1954 silly addNameRange     '1.2.0',
+1954 silly addNameRange     '1.3.0',
+1954 silly addNameRange     '1.3.1',
+1954 silly addNameRange     '1.3.2',
+1954 silly addNameRange     '1.3.3',
+1954 silly addNameRange     '1.3.4',
+1954 silly addNameRange     '1.3.5',
+1954 silly addNameRange     '1.3.6',
+1954 silly addNameRange     '1.3.7',
+1954 silly addNameRange     '1.4.0',
+1954 silly addNameRange     '1.5.0',
+1954 silly addNameRange     '1.6.0',
+1954 silly addNameRange     '1.7.2',
+1954 silly addNameRange     '1.7.3',
+1954 silly addNameRange     '1.7.4',
+1954 silly addNameRange     '1.8.0',
+1954 silly addNameRange     '1.8.1',
+1954 silly addNameRange     '1.8.2',
+1954 silly addNameRange     '1.8.3',
+1954 silly addNameRange     '1.8.4',
+1954 silly addNameRange     '2.0.0',
+1954 silly addNameRange     '2.0.1',
+1954 silly addNameRange     '2.0.2',
+1954 silly addNameRange     '2.0.3',
+1954 silly addNameRange     '2.0.4',
+1954 silly addNameRange     '2.1.0',
+1954 silly addNameRange     '2.1.1',
+1954 silly addNameRange     '2.1.2',
+1954 silly addNameRange     '2.1.3',
+1954 silly addNameRange     '2.1.4',
+1954 silly addNameRange     '2.2.0',
+1954 silly addNameRange     '2.2.1',
+1954 silly addNameRange     '2.2.2',
+1954 silly addNameRange     '2.2.3',
+1954 silly addNameRange     '2.2.4',
+1954 silly addNameRange     '2.3.0',
+1954 silly addNameRange     '2.3.1',
+1954 silly addNameRange     '2.3.2',
+1954 silly addNameRange     '2.3.3',
+1954 silly addNameRange     '2.3.4',
+1954 silly addNameRange     '2.3.5',
+1954 silly addNameRange     '2.3.6',
+1954 silly addNameRange     '2.3.7',
+1954 silly addNameRange     '2.3.8',
+1954 silly addNameRange     '2.3.9',
+1954 silly addNameRange     '2.3.10',
+1954 silly addNameRange     '2.3.11',
+1954 silly addNameRange     '2.3.12',
+1954 silly addNameRange     '2.3.13',
+1954 silly addNameRange     '2.4.0',
+1954 silly addNameRange     '2.4.1',
+1954 silly addNameRange     '2.4.2',
+1954 silly addNameRange     '2.4.3',
+1954 silly addNameRange     '2.4.4',
+1954 silly addNameRange     '2.4.5',
+1954 silly addNameRange     '2.4.6',
+1954 silly addNameRange     '2.4.7',
+1954 silly addNameRange     '2.4.8',
+1954 silly addNameRange     '2.4.9',
+1954 silly addNameRange     '2.4.10',
+1954 silly addNameRange     '2.5.0',
+1954 silly addNameRange     '2.5.1',
+1954 silly addNameRange     '2.5.2',
+1954 silly addNameRange     '2.5.3',
+1954 silly addNameRange     '2.5.4',
+1954 silly addNameRange     '2.5.5',
+1954 silly addNameRange     '2.5.6',
+1954 silly addNameRange     '2.5.7',
+1954 silly addNameRange     '2.5.8',
+1954 silly addNameRange     '2.5.9',
+1954 silly addNameRange     '2.5.10',
+1954 silly addNameRange     '2.5.11',
+1954 silly addNameRange     '2.5.12',
+1954 silly addNameRange     '2.5.13',
+1954 silly addNameRange     '2.5.14',
+1954 silly addNameRange     '2.6.0',
+1954 silly addNameRange     '2.6.1',
+1954 silly addNameRange     '2.6.2',
+1954 silly addNameRange     '2.6.3',
+1954 silly addNameRange     '2.6.4',
+1954 silly addNameRange     '2.6.5',
+1954 silly addNameRange     '2.6.6',
+1954 silly addNameRange     '2.6.7',
+1954 silly addNameRange     '2.6.8',
+1954 silly addNameRange     '2.7.0',
+1954 silly addNameRange     '2.7.1',
+1954 silly addNameRange     '2.7.2',
+1954 silly addNameRange     '2.7.4',
+1954 silly addNameRange     '2.7.3',
+1954 silly addNameRange     '3.0.0',
+1954 silly addNameRange     '3.0.1',
+1954 silly addNameRange     '3.0.2',
+1954 silly addNameRange     '2.8.0',
+1954 silly addNameRange     '3.0.3',
+1954 silly addNameRange     '3.1.0',
+1954 silly addNameRange     '2.8.1',
+1954 silly addNameRange     '3.1.1',
+1954 silly addNameRange     '2.8.2',
+1954 silly addNameRange     '2.8.3',
+1954 silly addNameRange     '2.9.0',
+1954 silly addNameRange     '3.2.0',
+1954 silly addNameRange     '2.9.1',
+1954 silly addNameRange     '3.2.1',
+1954 silly addNameRange     '2.9.2',
+1954 silly addNameRange     '3.2.2',
+1954 silly addNameRange     '3.3.0',
+1954 silly addNameRange     '3.3.1',
+1954 silly addNameRange     '2.9.3',
+1954 silly addNameRange     '3.4.0',
+1954 silly addNameRange     '2.9.4',
+1954 silly addNameRange     '2.9.5',
+1954 silly addNameRange     '3.5.0',
+1954 silly addNameRange     '3.5.1',
+1954 silly addNameRange     '3.5.2',
+1954 silly addNameRange     '3.5.3',
+1954 silly addNameRange     '2.9.6',
+1954 silly addNameRange     '2.9.7',
+1954 silly addNameRange     '3.5.4',
+1954 silly addNameRange     '3.5.5',
+1954 silly addNameRange     '2.9.8',
+1954 silly addNameRange     '2.9.9',
+1954 silly addNameRange     '3.5.6',
+1954 silly addNameRange     '3.5.7',
+1954 silly addNameRange     '3.5.8',
+1954 silly addNameRange     '2.9.10',
+1954 silly addNameRange     '3.5.9',
+1954 silly addNameRange     '3.6.2',
+1954 silly addNameRange     '3.5.10',
+1954 silly addNameRange     '3.6.3',
+1954 silly addNameRange     '3.5.11',
+1954 silly addNameRange     '3.6.4',
+1954 silly addNameRange     '3.6.5',
+1954 silly addNameRange     '3.6.6',
+1954 silly addNameRange     '3.6.7',
+1954 silly addNameRange     '3.5.12',
+1954 silly addNameRange     '3.6.8',
+1954 silly addNameRange     '3.6.9',
+1954 silly addNameRange     '3.6.10',
+1954 silly addNameRange     '3.5.13',
+1954 silly addNameRange     '3.5.14',
+1954 silly addNameRange     '3.6.11',
+1954 silly addNameRange     '3.6.12',
+1954 silly addNameRange     '3.6.13',
+1954 silly addNameRange     '3.6.14',
+1954 silly addNameRange     '3.6.15',
+1954 silly addNameRange     '3.5.15',
+1954 silly addNameRange     '3.7.0',
+1954 silly addNameRange     '3.6.16',
+1954 silly addNameRange     '3.5.16',
+1954 silly addNameRange     '3.6.17',
+1954 silly addNameRange     '3.7.2',
+1954 silly addNameRange     '3.0.0-alpha1',
+1954 silly addNameRange     '3.0.0-alpha2',
+1954 silly addNameRange     '3.0.0-rc0',
+1954 silly addNameRange     '3.6.0-rc0',
+1954 silly addNameRange     '3.6.0-rc1',
+1954 silly addNameRange     '3.6.18',
+1954 silly addNameRange     '3.7.3',
+1954 silly addNameRange     '3.6.19',
+1954 silly addNameRange     '3.6.20',
+1954 silly addNameRange     '3.7.4',
+1954 silly addNameRange     '3.8.0',
+1954 silly addNameRange     '3.8.1',
+1954 silly addNameRange     '3.8.2',
+1954 silly addNameRange     '3.8.3',
+1954 silly addNameRange     '3.8.4',
+1954 silly addNameRange     '3.8.5',
+1954 silly addNameRange     '3.8.6',
+1954 silly addNameRange     '3.8.7',
+1954 silly addNameRange     '3.8.8',
+1954 silly addNameRange     '3.8.9',
+1954 silly addNameRange     '3.8.10',
+1954 silly addNameRange     '3.8.11',
+1954 silly addNameRange     '3.9.0',
+1954 silly addNameRange     '3.8.12',
+1954 silly addNameRange     '3.8.13',
+1954 silly addNameRange     '3.8.14',
+1954 silly addNameRange     '3.8.15',
+1954 silly addNameRange     '3.9.1',
+1954 silly addNameRange     '3.8.16',
+1954 silly addNameRange     '3.9.2',
+1954 silly addNameRange     '3.8.17',
+1954 silly addNameRange     '3.9.3',
+1954 silly addNameRange     '3.8.18',
+1954 silly addNameRange     '3.9.4',
+1954 silly addNameRange     '3.8.19',
+1954 silly addNameRange     '3.9.5',
+1954 silly addNameRange     '3.8.20',
+1954 silly addNameRange     '3.9.6',
+1954 silly addNameRange     '3.8.21',
+1954 silly addNameRange     '3.9.7',
+1954 silly addNameRange     '3.8.22',
+1954 silly addNameRange     '4.0.0-rc0',
+1954 silly addNameRange     '4.0.0-rc1',
+1954 silly addNameRange     '3.8.23',
+1954 silly addNameRange     '4.0.0-rc2',
+1954 silly addNameRange     '3.8.24',
+1954 silly addNameRange     '4.0.0-rc3',
+1954 silly addNameRange     '3.8.25',
+1954 silly addNameRange     '4.0.0-rc4',
+1954 silly addNameRange     '4.0.0',
+1954 silly addNameRange     '4.0.1',
+1954 silly addNameRange     '3.8.26',
+1954 silly addNameRange     '3.8.27',
+1954 silly addNameRange     '4.0.2',
+1954 silly addNameRange     '3.8.28',
+1954 silly addNameRange     '4.0.3',
+1954 silly addNameRange     '3.8.29',
+1954 silly addNameRange     '4.0.4',
+1954 silly addNameRange     '3.8.30',
+1954 silly addNameRange     '4.0.5',
+1954 silly addNameRange     '3.8.31',
+1954 silly addNameRange     '4.0.6',
+1954 silly addNameRange     '3.8.33',
+1954 silly addNameRange     '4.0.7',
+1954 silly addNameRange     '3.8.34',
+1954 silly addNameRange     '4.0.8' ] ]
+1955 verbose addNamed mongoose@3.8.34
+1956 silly addNamed semver.valid 3.8.34
+1957 silly addNamed semver.validRange 3.8.34
+1958 silly addNameRange number 2 { name: 'decompress', range: '>=2.3.0 <3.0.0', hasData: true }
+1959 silly addNameRange versions [ 'decompress',
+1959 silly addNameRange   [ '0.1.0',
+1959 silly addNameRange     '0.1.1',
+1959 silly addNameRange     '0.1.2',
+1959 silly addNameRange     '0.1.3',
+1959 silly addNameRange     '0.1.4',
+1959 silly addNameRange     '0.1.5',
+1959 silly addNameRange     '0.1.6',
+1959 silly addNameRange     '0.1.7',
+1959 silly addNameRange     '0.1.8',
+1959 silly addNameRange     '0.1.9',
+1959 silly addNameRange     '0.2.0',
+1959 silly addNameRange     '0.2.1',
+1959 silly addNameRange     '0.2.2',
+1959 silly addNameRange     '0.2.3',
+1959 silly addNameRange     '0.2.4',
+1959 silly addNameRange     '0.3.0',
+1959 silly addNameRange     '0.3.1',
+1959 silly addNameRange     '0.3.2',
+1959 silly addNameRange     '0.3.3',
+1959 silly addNameRange     '1.0.0',
+1959 silly addNameRange     '1.0.1',
+1959 silly addNameRange     '1.0.2',
+1959 silly addNameRange     '1.0.3',
+1959 silly addNameRange     '1.0.4',
+1959 silly addNameRange     '0.2.5',
+1959 silly addNameRange     '0.1.10',
+1959 silly addNameRange     '1.0.5',
+1959 silly addNameRange     '1.0.6',
+1959 silly addNameRange     '1.0.7',
+1959 silly addNameRange     '2.0.0',
+1959 silly addNameRange     '2.1.0',
+1959 silly addNameRange     '2.1.1',
+1959 silly addNameRange     '2.1.2',
+1959 silly addNameRange     '2.2.0',
+1959 silly addNameRange     '2.2.1',
+1959 silly addNameRange     '2.3.0' ] ]
+1960 verbose addNamed decompress@2.3.0
+1961 silly addNamed semver.valid 2.3.0
+1962 silly addNamed semver.validRange 2.3.0
+1963 silly addNameRange number 2 { name: 'decompress-unzip',
+1963 silly addNameRange   range: '>=3.2.2 <4.0.0',
+1963 silly addNameRange   hasData: true }
+1964 silly addNameRange versions [ 'decompress-unzip',
+1964 silly addNameRange   [ '0.1.0',
+1964 silly addNameRange     '0.1.1',
+1964 silly addNameRange     '0.1.2',
+1964 silly addNameRange     '1.0.0',
+1964 silly addNameRange     '2.0.0',
+1964 silly addNameRange     '2.0.1',
+1964 silly addNameRange     '2.1.1',
+1964 silly addNameRange     '2.1.2',
+1964 silly addNameRange     '3.0.0',
+1964 silly addNameRange     '3.1.0',
+1964 silly addNameRange     '3.2.0',
+1964 silly addNameRange     '3.2.1',
+1964 silly addNameRange     '3.2.2',
+1964 silly addNameRange     '3.3.0' ] ]
+1965 verbose addNamed decompress-unzip@3.3.0
+1966 silly addNamed semver.valid 3.3.0
+1967 silly addNamed semver.validRange 3.3.0
+1968 silly addNameRange number 2 { name: 'mongoose-validators',
+1968 silly addNameRange   range: '>=0.1.0 <0.2.0',
+1968 silly addNameRange   hasData: true }
+1969 silly addNameRange versions [ 'mongoose-validators', [ '0.0.1', '0.1.0' ] ]
+1970 verbose addNamed mongoose-validators@0.1.0
+1971 silly addNamed semver.valid 0.1.0
+1972 silly addNamed semver.validRange 0.1.0
+1973 silly addNameRange number 2 { name: 'grunt-contrib-htmlmin',
+1973 silly addNameRange   range: '>=0.2.0 <0.3.0',
+1973 silly addNameRange   hasData: true }
+1974 silly addNameRange versions [ 'grunt-contrib-htmlmin',
+1974 silly addNameRange   [ '0.1.0',
+1974 silly addNameRange     '0.1.1',
+1974 silly addNameRange     '0.1.2',
+1974 silly addNameRange     '0.1.3',
+1974 silly addNameRange     '0.1.1-rc7',
+1974 silly addNameRange     '0.2.0',
+1974 silly addNameRange     '0.3.0',
+1974 silly addNameRange     '0.4.0' ] ]
+1975 verbose addNamed grunt-contrib-htmlmin@0.2.0
+1976 silly addNamed semver.valid 0.2.0
+1977 silly addNamed semver.validRange 0.2.0
+1978 silly addNameRange number 2 { name: 'promise', range: '>=7.0.1 <8.0.0', hasData: true }
+1979 silly addNameRange versions [ 'promise',
+1979 silly addNameRange   [ '1.2.1',
+1979 silly addNameRange     '1.2.2',
+1979 silly addNameRange     '1.3.0',
+1979 silly addNameRange     '2.0.0',
+1979 silly addNameRange     '3.0.0',
+1979 silly addNameRange     '3.0.1',
+1979 silly addNameRange     '3.1.0',
+1979 silly addNameRange     '3.2.0',
+1979 silly addNameRange     '4.0.0',
+1979 silly addNameRange     '5.0.0',
+1979 silly addNameRange     '6.0.0',
+1979 silly addNameRange     '6.0.1',
+1979 silly addNameRange     '6.1.0',
+1979 silly addNameRange     '7.0.0',
+1979 silly addNameRange     '7.0.1',
+1979 silly addNameRange     '7.0.2',
+1979 silly addNameRange     '7.0.3' ] ]
+1980 verbose addNamed promise@7.0.3
+1981 silly addNamed semver.valid 7.0.3
+1982 silly addNamed semver.validRange 7.0.3
+1983 silly addNameRange number 2 { name: 'grunt-concurrent',
+1983 silly addNameRange   range: '>=0.5.0 <0.6.0',
+1983 silly addNameRange   hasData: true }
+1984 silly addNameRange versions [ 'grunt-concurrent',
+1984 silly addNameRange   [ '0.1.0',
+1984 silly addNameRange     '0.1.1',
+1984 silly addNameRange     '0.2.0',
+1984 silly addNameRange     '0.3.0',
+1984 silly addNameRange     '0.3.1',
+1984 silly addNameRange     '0.4.0',
+1984 silly addNameRange     '0.4.1',
+1984 silly addNameRange     '0.4.2',
+1984 silly addNameRange     '0.4.3',
+1984 silly addNameRange     '0.5.0',
+1984 silly addNameRange     '1.0.0',
+1984 silly addNameRange     '1.0.1',
+1984 silly addNameRange     '2.0.0' ] ]
+1985 verbose addNamed grunt-concurrent@0.5.0
+1986 silly addNamed semver.valid 0.5.0
+1987 silly addNamed semver.validRange 0.5.0
+1988 silly addNameRange number 2 { name: 'morgan', range: '>=1.0.0 <1.1.0', hasData: true }
+1989 silly addNameRange versions [ 'morgan',
+1989 silly addNameRange   [ '1.0.0',
+1989 silly addNameRange     '1.0.1',
+1989 silly addNameRange     '1.1.0',
+1989 silly addNameRange     '1.1.1',
+1989 silly addNameRange     '1.2.0',
+1989 silly addNameRange     '1.2.1',
+1989 silly addNameRange     '1.2.2',
+1989 silly addNameRange     '1.2.3',
+1989 silly addNameRange     '1.3.0',
+1989 silly addNameRange     '1.3.1',
+1989 silly addNameRange     '1.3.2',
+1989 silly addNameRange     '1.4.0',
+1989 silly addNameRange     '1.4.1',
+1989 silly addNameRange     '1.5.0',
+1989 silly addNameRange     '1.5.1',
+1989 silly addNameRange     '1.5.2',
+1989 silly addNameRange     '1.5.3',
+1989 silly addNameRange     '1.6.0',
+1989 silly addNameRange     '1.6.1' ] ]
+1990 verbose addNamed morgan@1.0.1
+1991 silly addNamed semver.valid 1.0.1
+1992 silly addNamed semver.validRange 1.0.1
+1993 silly addNameRange number 2 { name: 'grunt-contrib-imagemin',
+1993 silly addNameRange   range: '>=0.7.1 <0.8.0',
+1993 silly addNameRange   hasData: true }
+1994 silly addNameRange versions [ 'grunt-contrib-imagemin',
+1994 silly addNameRange   [ '0.1.0',
+1994 silly addNameRange     '0.1.1',
+1994 silly addNameRange     '0.1.2',
+1994 silly addNameRange     '0.1.3',
+1994 silly addNameRange     '0.1.4',
+1994 silly addNameRange     '0.1.1-rc7',
+1994 silly addNameRange     '0.1.1-rc8',
+1994 silly addNameRange     '0.2.0',
+1994 silly addNameRange     '0.2.1',
+1994 silly addNameRange     '0.3.0',
+1994 silly addNameRange     '0.4.0',
+1994 silly addNameRange     '0.4.1',
+1994 silly addNameRange     '0.5.0',
+1994 silly addNameRange     '0.6.0',
+1994 silly addNameRange     '0.6.1',
+1994 silly addNameRange     '0.7.0',
+1994 silly addNameRange     '0.7.1',
+1994 silly addNameRange     '0.7.2',
+1994 silly addNameRange     '0.8.0',
+1994 silly addNameRange     '0.8.1',
+1994 silly addNameRange     '0.9.0',
+1994 silly addNameRange     '0.9.1',
+1994 silly addNameRange     '0.9.2',
+1994 silly addNameRange     '0.9.3',
+1994 silly addNameRange     '0.9.4' ] ]
+1995 verbose addNamed grunt-contrib-imagemin@0.7.2
+1996 silly addNamed semver.valid 0.7.2
+1997 silly addNamed semver.validRange 0.7.2
+1998 silly addNameRange number 2 { name: 'jade', range: '>=1.2.0 <1.3.0', hasData: true }
+1999 silly addNameRange versions [ 'jade',
+1999 silly addNameRange   [ '0.0.1',
+1999 silly addNameRange     '0.0.2',
+1999 silly addNameRange     '0.1.0',
+1999 silly addNameRange     '0.2.0',
+1999 silly addNameRange     '0.2.1',
+1999 silly addNameRange     '0.2.2',
+1999 silly addNameRange     '0.2.3',
+1999 silly addNameRange     '0.2.4',
+1999 silly addNameRange     '0.3.0',
+1999 silly addNameRange     '0.4.0',
+1999 silly addNameRange     '0.4.1',
+1999 silly addNameRange     '0.5.0',
+1999 silly addNameRange     '0.5.1',
+1999 silly addNameRange     '0.5.2',
+1999 silly addNameRange     '0.5.3',
+1999 silly addNameRange     '0.5.4',
+1999 silly addNameRange     '0.5.5',
+1999 silly addNameRange     '0.5.6',
+1999 silly addNameRange     '0.5.7',
+1999 silly addNameRange     '0.6.0',
+1999 silly addNameRange     '0.6.1',
+1999 silly addNameRange     '0.6.3',
+1999 silly addNameRange     '0.7.0',
+1999 silly addNameRange     '0.7.1',
+1999 silly addNameRange     '0.8.0',
+1999 silly addNameRange     '0.8.1',
+1999 silly addNameRange     '0.8.2',
+1999 silly addNameRange     '0.8.3',
+1999 silly addNameRange     '0.8.4',
+1999 silly addNameRange     '0.8.5',
+1999 silly addNameRange     '0.8.6',
+1999 silly addNameRange     '0.8.7',
+1999 silly addNameRange     '0.8.8',
+1999 silly addNameRange     '0.8.9',
+1999 silly addNameRange     '0.9.0',
+1999 silly addNameRange     '0.9.1',
+1999 silly addNameRange     '0.9.2',
+1999 silly addNameRange     '0.9.3',
+1999 silly addNameRange     '0.10.0',
+1999 silly addNameRange     '0.10.1',
+1999 silly addNameRange     '0.10.2',
+1999 silly addNameRange     '0.10.3',
+1999 silly addNameRange     '0.10.4',
+1999 silly addNameRange     '0.10.5',
+1999 silly addNameRange     '0.10.6',
+1999 silly addNameRange     '0.10.7',
+1999 silly addNameRange     '0.11.0',
+1999 silly addNameRange     '0.11.1',
+1999 silly addNameRange     '0.12.0',
+1999 silly addNameRange     '0.12.1',
+1999 silly addNameRange     '0.12.2',
+1999 silly addNameRange     '0.12.3',
+1999 silly addNameRange     '0.12.4',
+1999 silly addNameRange     '0.13.0',
+1999 silly addNameRange     '0.14.0',
+1999 silly addNameRange     '0.14.1',
+1999 silly addNameRange     '0.14.2',
+1999 silly addNameRange     '0.15.0',
+1999 silly addNameRange     '0.15.1',
+1999 silly addNameRange     '0.15.2',
+1999 silly addNameRange     '0.15.3',
+1999 silly addNameRange     '0.15.4',
+1999 silly addNameRange     '0.16.0',
+1999 silly addNameRange     '0.16.1',
+1999 silly addNameRange     '0.16.2',
+1999 silly addNameRange     '0.16.3',
+1999 silly addNameRange     '0.16.4',
+1999 silly addNameRange     '0.17.0',
+1999 silly addNameRange     '0.18.0',
+1999 silly addNameRange     '0.19.0',
+1999 silly addNameRange     '0.20.0',
+1999 silly addNameRange     '0.20.1',
+1999 silly addNameRange     '0.20.2',
+1999 silly addNameRange     '0.20.3',
+1999 silly addNameRange     '0.21.0',
+1999 silly addNameRange     '0.22.0',
+1999 silly addNameRange     '0.22.1',
+1999 silly addNameRange     '0.23.0',
+1999 silly addNameRange     '0.24.0',
+1999 silly addNameRange     '0.25.0',
+1999 silly addNameRange     '0.26.0',
+1999 silly addNameRange     '0.26.1',
+1999 silly addNameRange     '0.26.2',
+1999 silly addNameRange     '0.26.3',
+1999 silly addNameRange     '0.27.0',
+1999 silly addNameRange     '0.27.1',
+1999 silly addNameRange     '0.27.2',
+1999 silly addNameRange     '0.27.3',
+1999 silly addNameRange     '0.27.4',
+1999 silly addNameRange     '0.27.5',
+1999 silly addNameRange     '0.27.6',
+1999 silly addNameRange     '0.27.7',
+1999 silly addNameRange     '0.28.0',
+1999 silly addNameRange     '0.28.1',
+1999 silly addNameRange     '0.28.2',
+1999 silly addNameRange     '0.29.0',
+1999 silly addNameRange     '0.30.0',
+1999 silly addNameRange     '0.31.0',
+1999 silly addNameRange     '0.31.1',
+1999 silly addNameRange     '0.31.2',
+1999 silly addNameRange     '0.32.0',
+1999 silly addNameRange     '0.33.0',
+1999 silly addNameRange     '0.34.0',
+1999 silly addNameRange     '0.34.1',
+1999 silly addNameRange     '0.35.0',
+1999 silly addNameRange     '1.0.0',
+1999 silly addNameRange     '1.0.1',
+1999 silly addNameRange     '1.0.2',
+1999 silly addNameRange     '1.1.0',
+1999 silly addNameRange     '1.1.1',
+1999 silly addNameRange     '1.1.2',
+1999 silly addNameRange     '1.1.3',
+1999 silly addNameRange     '1.1.4',
+1999 silly addNameRange     '1.1.5',
+1999 silly addNameRange     '1.2.0',
+1999 silly addNameRange     '1.3.0',
+1999 silly addNameRange     '1.3.1',
+1999 silly addNameRange     '1.4.0',
+1999 silly addNameRange     '1.4.1',
+1999 silly addNameRange     '1.4.2',
+1999 silly addNameRange     '1.5.0',
+1999 silly addNameRange     '1.6.0',
+1999 silly addNameRange     '1.7.0',
+1999 silly addNameRange     '1.8.0',
+1999 silly addNameRange     '1.8.1',
+1999 silly addNameRange     '1.8.2',
+1999 silly addNameRange     '1.9.0',
+1999 silly addNameRange     '1.9.1',
+1999 silly addNameRange     '1.9.2',
+1999 silly addNameRange     '1.10.0',
+1999 silly addNameRange     '1.11.0' ] ]
+2000 verbose addNamed jade@1.2.0
+2001 silly addNamed semver.valid 1.2.0
+2002 silly addNamed semver.validRange 1.2.0
+2003 silly addNameRange number 2 { name: 'grunt-mocha-test',
+2003 silly addNameRange   range: '>=0.10.2 <0.11.0',
+2003 silly addNameRange   hasData: true }
+2004 silly addNameRange versions [ 'grunt-mocha-test',
+2004 silly addNameRange   [ '0.0.1',
+2004 silly addNameRange     '0.1.0',
+2004 silly addNameRange     '0.1.1',
+2004 silly addNameRange     '0.2.0',
+2004 silly addNameRange     '0.2.1',
+2004 silly addNameRange     '0.2.2',
+2004 silly addNameRange     '0.3.0',
+2004 silly addNameRange     '0.3.1',
+2004 silly addNameRange     '0.3.2',
+2004 silly addNameRange     '0.3.3',
+2004 silly addNameRange     '0.3.4',
+2004 silly addNameRange     '0.3.5',
+2004 silly addNameRange     '0.4.0',
+2004 silly addNameRange     '0.5.0',
+2004 silly addNameRange     '0.6.0',
+2004 silly addNameRange     '0.6.1',
+2004 silly addNameRange     '0.6.2',
+2004 silly addNameRange     '0.6.3',
+2004 silly addNameRange     '0.7.0',
+2004 silly addNameRange     '0.8.0',
+2004 silly addNameRange     '0.8.1',
+2004 silly addNameRange     '0.8.2',
+2004 silly addNameRange     '0.9.0',
+2004 silly addNameRange     '0.9.1',
+2004 silly addNameRange     '0.9.2',
+2004 silly addNameRange     '0.9.3',
+2004 silly addNameRange     '0.9.4',
+2004 silly addNameRange     '0.10.0',
+2004 silly addNameRange     '0.10.1',
+2004 silly addNameRange     '0.10.2',
+2004 silly addNameRange     '0.11.0',
+2004 silly addNameRange     '0.12.0',
+2004 silly addNameRange     '0.12.1',
+2004 silly addNameRange     '0.12.2',
+2004 silly addNameRange     '0.12.3',
+2004 silly addNameRange     '0.12.4',
+2004 silly addNameRange     '0.12.5',
+2004 silly addNameRange     '0.12.6',
+2004 silly addNameRange     '0.12.7' ] ]
+2005 verbose addNamed grunt-mocha-test@0.10.2
+2006 silly addNamed semver.valid 0.10.2
+2007 silly addNamed semver.validRange 0.10.2
+2008 silly addNameRange number 2 { name: 'connect-livereload',
+2008 silly addNameRange   range: '>=0.4.0 <0.5.0',
+2008 silly addNameRange   hasData: true }
+2009 silly addNameRange versions [ 'connect-livereload',
+2009 silly addNameRange   [ '0.0.2',
+2009 silly addNameRange     '0.0.3',
+2009 silly addNameRange     '0.1.0',
+2009 silly addNameRange     '0.1.1',
+2009 silly addNameRange     '0.1.2',
+2009 silly addNameRange     '0.1.3',
+2009 silly addNameRange     '0.1.4',
+2009 silly addNameRange     '0.2.0',
+2009 silly addNameRange     '0.3.0',
+2009 silly addNameRange     '0.3.1',
+2009 silly addNameRange     '0.3.2',
+2009 silly addNameRange     '0.4.0',
+2009 silly addNameRange     '0.4.1',
+2009 silly addNameRange     '0.5.0',
+2009 silly addNameRange     '0.5.1',
+2009 silly addNameRange     '0.5.2',
+2009 silly addNameRange     '0.5.3' ] ]
+2010 verbose addNamed connect-livereload@0.4.1
+2011 silly addNamed semver.valid 0.4.1
+2012 silly addNamed semver.validRange 0.4.1
+2013 http 200 https://registry.npmjs.org/grunt-autoprefixer
+2014 silly get cb [ 200,
+2014 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+2014 silly get     etag: '"7H8SZF1RKL48P6ELTYARQS6NN"',
+2014 silly get     'content-type': 'application/json',
+2014 silly get     'cache-control': 'max-age=60',
+2014 silly get     'content-length': '61681',
+2014 silly get     'accept-ranges': 'bytes',
+2014 silly get     date: 'Thu, 23 Jul 2015 17:45:59 GMT',
+2014 silly get     via: '1.1 varnish',
+2014 silly get     age: '0',
+2014 silly get     connection: 'keep-alive',
+2014 silly get     'x-served-by': 'cache-lax1422-LAX',
+2014 silly get     'x-cache': 'HIT',
+2014 silly get     'x-cache-hits': '1',
+2014 silly get     'x-timer': 'S1437673559.253776,VS0,VE49',
+2014 silly get     vary: 'Accept' } ]
+2015 verbose get saving grunt-autoprefixer to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-autoprefixer\.cache.json
+2016 http 200 https://registry.npmjs.org/grunt-contrib-jshint
+2017 silly get cb [ 200,
+2017 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+2017 silly get     etag: '"EIN34535ZVL5QKIRESQJX4ESB"',
+2017 silly get     'content-type': 'application/json',
+2017 silly get     'cache-control': 'max-age=60',
+2017 silly get     'content-length': '59337',
+2017 silly get     'accept-ranges': 'bytes',
+2017 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+2017 silly get     via: '1.1 varnish',
+2017 silly get     age: '0',
+2017 silly get     connection: 'keep-alive',
+2017 silly get     'x-served-by': 'cache-lax1426-LAX',
+2017 silly get     'x-cache': 'HIT',
+2017 silly get     'x-cache-hits': '1',
+2017 silly get     'x-timer': 'S1437673558.792038,VS0,VE76',
+2017 silly get     vary: 'Accept' } ]
+2018 verbose get saving grunt-contrib-jshint to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\grunt-contrib-jshint\.cache.json
+2019 silly mapToRegistry name mongoose
+2020 silly mapToRegistry using default registry
+2021 silly mapToRegistry registry https://registry.npmjs.org/
+2022 silly mapToRegistry uri https://registry.npmjs.org/mongoose
+2023 verbose addRemoteTarball https://registry.npmjs.org/mongoose/-/mongoose-3.8.34.tgz not in flight; adding
+2024 verbose addRemoteTarball [ 'https://registry.npmjs.org/mongoose/-/mongoose-3.8.34.tgz',
+2024 verbose addRemoteTarball   '42d43528270c5771bff43fdc74ce2798fb21b691' ]
+2025 http 200 https://registry.npmjs.org/gm
+2026 silly get cb [ 200,
+2026 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+2026 silly get     etag: '"9VHEUMQYS543W3LYIJMO7KR2G"',
+2026 silly get     'content-type': 'application/json',
+2026 silly get     'cache-control': 'max-age=60',
+2026 silly get     'content-length': '89062',
+2026 silly get     'accept-ranges': 'bytes',
+2026 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+2026 silly get     via: '1.1 varnish',
+2026 silly get     age: '51',
+2026 silly get     connection: 'keep-alive',
+2026 silly get     'x-served-by': 'cache-lax1432-LAX',
+2026 silly get     'x-cache': 'HIT',
+2026 silly get     'x-cache-hits': '2',
+2026 silly get     'x-timer': 'S1437673558.823475,VS0,VE0',
+2026 silly get     vary: 'Accept' } ]
+2027 verbose get saving gm to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\gm\.cache.json
+2028 silly mapToRegistry name promise
+2029 silly mapToRegistry using default registry
+2030 silly mapToRegistry registry https://registry.npmjs.org/
+2031 silly mapToRegistry uri https://registry.npmjs.org/promise
+2032 verbose addRemoteTarball https://registry.npmjs.org/promise/-/promise-7.0.3.tgz not in flight; adding
+2033 verbose addRemoteTarball [ 'https://registry.npmjs.org/promise/-/promise-7.0.3.tgz',
+2033 verbose addRemoteTarball   '1c467fdea4cbb2564357e6e90fcc9d559066d66f' ]
+2034 http fetch 200 https://registry.npmjs.org/mongoose-text-search/-/mongoose-text-search-0.0.2.tgz
+2035 silly addNameRange number 2 { name: 'grunt-node-inspector',
+2035 silly addNameRange   range: '>=0.1.5 <0.2.0',
+2035 silly addNameRange   hasData: true }
+2036 silly addNameRange versions [ 'grunt-node-inspector',
+2036 silly addNameRange   [ '0.0.1',
+2036 silly addNameRange     '0.1.0',
+2036 silly addNameRange     '0.1.1',
+2036 silly addNameRange     '0.1.2',
+2036 silly addNameRange     '0.1.3',
+2036 silly addNameRange     '0.1.5',
+2036 silly addNameRange     '0.1.6',
+2036 silly addNameRange     '0.2.0' ] ]
+2037 verbose addNamed grunt-node-inspector@0.1.6
+2038 silly addNamed semver.valid 0.1.6
+2039 silly addNamed semver.validRange 0.1.6
+2040 silly addNameRange number 2 { name: 'grunt-dom-munger',
+2040 silly addNameRange   range: '>=3.4.0 <4.0.0',
+2040 silly addNameRange   hasData: true }
+2041 silly addNameRange versions [ 'grunt-dom-munger',
+2041 silly addNameRange   [ '0.1.0',
+2041 silly addNameRange     '0.2.0',
+2041 silly addNameRange     '1.0.0',
+2041 silly addNameRange     '1.0.1',
+2041 silly addNameRange     '2.0.0',
+2041 silly addNameRange     '2.0.1',
+2041 silly addNameRange     '3.0.0',
+2041 silly addNameRange     '3.0.1',
+2041 silly addNameRange     '3.1.0',
+2041 silly addNameRange     '3.2.0',
+2041 silly addNameRange     '3.3.0',
+2041 silly addNameRange     '3.4.0' ] ]
+2042 verbose addNamed grunt-dom-munger@3.4.0
+2043 silly addNamed semver.valid 3.4.0
+2044 silly addNamed semver.validRange 3.4.0
+2045 silly addNameRange number 2 { name: 'prerender-node',
+2045 silly addNameRange   range: '>=1.2.1 <2.0.0',
+2045 silly addNameRange   hasData: true }
+2046 silly addNameRange versions [ 'prerender-node',
+2046 silly addNameRange   [ '0.0.1',
+2046 silly addNameRange     '0.0.2',
+2046 silly addNameRange     '0.0.3',
+2046 silly addNameRange     '0.0.4',
+2046 silly addNameRange     '0.0.5',
+2046 silly addNameRange     '0.0.6',
+2046 silly addNameRange     '0.0.7',
+2046 silly addNameRange     '0.0.8',
+2046 silly addNameRange     '0.0.9',
+2046 silly addNameRange     '0.1.0',
+2046 silly addNameRange     '0.1.1',
+2046 silly addNameRange     '0.1.2',
+2046 silly addNameRange     '0.1.3',
+2046 silly addNameRange     '0.1.4',
+2046 silly addNameRange     '0.1.5',
+2046 silly addNameRange     '0.1.6',
+2046 silly addNameRange     '0.1.7',
+2046 silly addNameRange     '0.1.8',
+2046 silly addNameRange     '0.1.9',
+2046 silly addNameRange     '0.1.11',
+2046 silly addNameRange     '0.1.12',
+2046 silly addNameRange     '0.1.13',
+2046 silly addNameRange     '0.1.14',
+2046 silly addNameRange     '0.1.15',
+2046 silly addNameRange     '0.1.16',
+2046 silly addNameRange     '0.1.17',
+2046 silly addNameRange     '0.1.18',
+2046 silly addNameRange     '0.1.19',
+2046 silly addNameRange     '1.0.0',
+2046 silly addNameRange     '1.0.1',
+2046 silly addNameRange     '1.0.2',
+2046 silly addNameRange     '1.0.3',
+2046 silly addNameRange     '1.0.4',
+2046 silly addNameRange     '1.0.5',
+2046 silly addNameRange     '1.0.6',
+2046 silly addNameRange     '1.1.0',
+2046 silly addNameRange     '1.1.1',
+2046 silly addNameRange     '1.2.0',
+2046 silly addNameRange     '1.2.1',
+2046 silly addNameRange     '1.3.0',
+2046 silly addNameRange     '2.0.0',
+2046 silly addNameRange     '2.0.1' ] ]
+2047 verbose addNamed prerender-node@1.3.0
+2048 silly addNamed semver.valid 1.3.0
+2049 silly addNamed semver.validRange 1.3.0
+2050 silly addNameRange number 2 { name: 'grunt-docco', range: '>=0.3.3 <0.4.0', hasData: true }
+2051 silly addNameRange versions [ 'grunt-docco',
+2051 silly addNameRange   [ '0.1.0',
+2051 silly addNameRange     '0.1.1',
+2051 silly addNameRange     '0.1.2',
+2051 silly addNameRange     '0.2.0',
+2051 silly addNameRange     '0.3.0',
+2051 silly addNameRange     '0.3.1',
+2051 silly addNameRange     '0.3.2',
+2051 silly addNameRange     '0.3.3' ] ]
+2052 verbose addNamed grunt-docco@0.3.3
+2053 silly addNamed semver.valid 0.3.3
+2054 silly addNamed semver.validRange 0.3.3
+2055 silly addNameRange number 2 { name: 'karma-chrome-launcher',
+2055 silly addNameRange   range: '>=0.1.3 <0.2.0',
+2055 silly addNameRange   hasData: true }
+2056 silly addNameRange versions [ 'karma-chrome-launcher',
+2056 silly addNameRange   [ '0.0.1',
+2056 silly addNameRange     '0.0.2',
+2056 silly addNameRange     '0.1.0',
+2056 silly addNameRange     '0.1.1',
+2056 silly addNameRange     '0.1.2',
+2056 silly addNameRange     '0.1.3',
+2056 silly addNameRange     '0.1.4',
+2056 silly addNameRange     '0.1.5',
+2056 silly addNameRange     '0.1.6',
+2056 silly addNameRange     '0.1.7',
+2056 silly addNameRange     '0.1.8',
+2056 silly addNameRange     '0.1.9',
+2056 silly addNameRange     '0.1.10',
+2056 silly addNameRange     '0.1.11',
+2056 silly addNameRange     '0.1.12',
+2056 silly addNameRange     '0.2.0' ] ]
+2057 verbose addNamed karma-chrome-launcher@0.1.12
+2058 silly addNamed semver.valid 0.1.12
+2059 silly addNamed semver.validRange 0.1.12
+2060 silly addNameRange number 2 { name: 'karma-phantomjs-launcher',
+2060 silly addNameRange   range: '>=0.1.4 <0.2.0',
+2060 silly addNameRange   hasData: true }
+2061 silly addNameRange versions [ 'karma-phantomjs-launcher',
+2061 silly addNameRange   [ '0.0.1',
+2061 silly addNameRange     '0.0.2',
+2061 silly addNameRange     '0.0.3',
+2061 silly addNameRange     '0.1.0',
+2061 silly addNameRange     '0.1.1',
+2061 silly addNameRange     '0.1.2',
+2061 silly addNameRange     '0.1.3',
+2061 silly addNameRange     '0.1.4',
+2061 silly addNameRange     '0.2.0' ] ]
+2062 verbose addNamed karma-phantomjs-launcher@0.1.4
+2063 silly addNamed semver.valid 0.1.4
+2064 silly addNamed semver.validRange 0.1.4
+2065 silly addNameRange number 2 { name: 'jshint-stylish',
+2065 silly addNameRange   range: '>=0.1.5 <0.2.0',
+2065 silly addNameRange   hasData: true }
+2066 silly addNameRange versions [ 'jshint-stylish',
+2066 silly addNameRange   [ '0.1.0',
+2066 silly addNameRange     '0.1.1',
+2066 silly addNameRange     '0.1.2',
+2066 silly addNameRange     '0.1.3',
+2066 silly addNameRange     '0.1.4',
+2066 silly addNameRange     '0.1.5',
+2066 silly addNameRange     '0.2.0',
+2066 silly addNameRange     '0.3.0',
+2066 silly addNameRange     '0.4.0',
+2066 silly addNameRange     '1.0.0',
+2066 silly addNameRange     '1.0.1',
+2066 silly addNameRange     '1.0.2',
+2066 silly addNameRange     '2.0.0',
+2066 silly addNameRange     '2.0.1' ] ]
+2067 verbose addNamed jshint-stylish@0.1.5
+2068 silly addNamed semver.valid 0.1.5
+2069 silly addNamed semver.validRange 0.1.5
+2070 silly addNameRange number 2 { name: 'body-parser', range: '>=1.5.0 <1.6.0', hasData: true }
+2071 silly addNameRange versions [ 'body-parser',
+2071 silly addNameRange   [ '1.0.0',
+2071 silly addNameRange     '1.0.1',
+2071 silly addNameRange     '1.0.2',
+2071 silly addNameRange     '1.1.0',
+2071 silly addNameRange     '1.1.1',
+2071 silly addNameRange     '1.1.2',
+2071 silly addNameRange     '1.2.0',
+2071 silly addNameRange     '1.2.1',
+2071 silly addNameRange     '1.2.2',
+2071 silly addNameRange     '1.3.0',
+2071 silly addNameRange     '1.3.1',
+2071 silly addNameRange     '1.4.0',
+2071 silly addNameRange     '1.4.1',
+2071 silly addNameRange     '1.4.2',
+2071 silly addNameRange     '1.4.3',
+2071 silly addNameRange     '1.5.0',
+2071 silly addNameRange     '1.5.1',
+2071 silly addNameRange     '1.5.2',
+2071 silly addNameRange     '1.6.0',
+2071 silly addNameRange     '1.6.1',
+2071 silly addNameRange     '1.6.2',
+2071 silly addNameRange     '1.6.3',
+2071 silly addNameRange     '1.6.4',
+2071 silly addNameRange     '1.6.5',
+2071 silly addNameRange     '1.6.6',
+2071 silly addNameRange     '1.6.7',
+2071 silly addNameRange     '1.7.0',
+2071 silly addNameRange     '1.8.0',
+2071 silly addNameRange     '1.8.1',
+2071 silly addNameRange     '1.8.2',
+2071 silly addNameRange     '1.8.3',
+2071 silly addNameRange     '1.8.4',
+2071 silly addNameRange     '1.9.0',
+2071 silly addNameRange     '1.9.1',
+2071 silly addNameRange     '1.9.2',
+2071 silly addNameRange     '1.9.3',
+2071 silly addNameRange     '1.10.0',
+2071 silly addNameRange     '1.10.1',
+2071 silly addNameRange     '1.10.2',
+2071 silly addNameRange     '1.11.0',
+2071 silly addNameRange     '1.12.0',
+2071 silly addNameRange     '1.12.1',
+2071 silly addNameRange     '1.12.2',
+2071 silly addNameRange     '1.12.3',
+2071 silly addNameRange     '1.12.4',
+2071 silly addNameRange     '1.13.0',
+2071 silly addNameRange     '1.13.1',
+2071 silly addNameRange     '1.13.2' ] ]
+2072 verbose addNamed body-parser@1.5.2
+2073 silly addNamed semver.valid 1.5.2
+2074 silly addNamed semver.validRange 1.5.2
+2075 silly addNameRange number 2 { name: 'karma-script-launcher',
+2075 silly addNameRange   range: '>=0.1.0 <0.2.0',
+2075 silly addNameRange   hasData: true }
+2076 silly addNameRange versions [ 'karma-script-launcher', [ '0.0.1', '0.0.2', '0.1.0' ] ]
+2077 verbose addNamed karma-script-launcher@0.1.0
+2078 silly addNamed semver.valid 0.1.0
+2079 silly addNamed semver.validRange 0.1.0
+2080 silly addNameRange number 2 { name: 'grunt-google-cdn',
+2080 silly addNameRange   range: '>=0.4.0 <0.5.0',
+2080 silly addNameRange   hasData: true }
+2081 silly addNameRange versions [ 'grunt-google-cdn',
+2081 silly addNameRange   [ '0.0.1',
+2081 silly addNameRange     '0.1.0',
+2081 silly addNameRange     '0.1.1',
+2081 silly addNameRange     '0.1.2',
+2081 silly addNameRange     '0.1.3',
+2081 silly addNameRange     '0.1.4',
+2081 silly addNameRange     '0.2.0',
+2081 silly addNameRange     '0.2.1',
+2081 silly addNameRange     '0.2.2',
+2081 silly addNameRange     '0.3.0',
+2081 silly addNameRange     '0.4.0',
+2081 silly addNameRange     '0.4.1',
+2081 silly addNameRange     '0.4.2',
+2081 silly addNameRange     '0.4.3' ] ]
+2082 verbose addNamed grunt-google-cdn@0.4.3
+2083 silly addNamed semver.valid 0.4.3
+2084 silly addNamed semver.validRange 0.4.3
+2085 silly addNameRange number 2 { name: 'grunt-protractor-runner',
+2085 silly addNameRange   range: '>=1.1.0 <2.0.0',
+2085 silly addNameRange   hasData: true }
+2086 silly addNameRange versions [ 'grunt-protractor-runner',
+2086 silly addNameRange   [ '0.1.0',
+2086 silly addNameRange     '0.1.1',
+2086 silly addNameRange     '0.1.2',
+2086 silly addNameRange     '0.1.3',
+2086 silly addNameRange     '0.1.4',
+2086 silly addNameRange     '0.1.5',
+2086 silly addNameRange     '0.1.6',
+2086 silly addNameRange     '0.1.7',
+2086 silly addNameRange     '0.1.8',
+2086 silly addNameRange     '0.1.9',
+2086 silly addNameRange     '0.1.10',
+2086 silly addNameRange     '0.1.11',
+2086 silly addNameRange     '0.2.0',
+2086 silly addNameRange     '0.2.1',
+2086 silly addNameRange     '0.2.2',
+2086 silly addNameRange     '0.2.3',
+2086 silly addNameRange     '0.2.4',
+2086 silly addNameRange     '0.2.5',
+2086 silly addNameRange     '1.0.0',
+2086 silly addNameRange     '1.0.1',
+2086 silly addNameRange     '1.1.0',
+2086 silly addNameRange     '1.1.1',
+2086 silly addNameRange     '1.1.2',
+2086 silly addNameRange     '1.1.3',
+2086 silly addNameRange     '1.1.4',
+2086 silly addNameRange     '1.2.0',
+2086 silly addNameRange     '1.2.1',
+2086 silly addNameRange     '2.0.0' ] ]
+2087 verbose addNamed grunt-protractor-runner@1.2.1
+2088 silly addNamed semver.valid 1.2.1
+2089 silly addNamed semver.validRange 1.2.1
+2090 silly addNameRange number 2 { name: 'grunt-rev', range: '>=0.1.0 <0.2.0', hasData: true }
+2091 silly addNameRange versions [ 'grunt-rev', [ '0.1.0' ] ]
+2092 verbose addNamed grunt-rev@0.1.0
+2093 silly addNamed semver.valid 0.1.0
+2094 silly addNamed semver.validRange 0.1.0
+2095 silly addNameRange number 2 { name: 'grunt-contrib-cssmin',
+2095 silly addNameRange   range: '>=0.9.0 <0.10.0',
+2095 silly addNameRange   hasData: true }
+2096 silly addNameRange versions [ 'grunt-contrib-cssmin',
+2096 silly addNameRange   [ '0.4.0',
+2096 silly addNameRange     '0.4.1',
+2096 silly addNameRange     '0.4.2',
+2096 silly addNameRange     '0.5.0',
+2096 silly addNameRange     '0.6.0',
+2096 silly addNameRange     '0.6.1',
+2096 silly addNameRange     '0.6.2',
+2096 silly addNameRange     '0.7.0',
+2096 silly addNameRange     '0.8.0',
+2096 silly addNameRange     '0.9.0',
+2096 silly addNameRange     '0.10.0',
+2096 silly addNameRange     '0.11.0',
+2096 silly addNameRange     '0.12.0',
+2096 silly addNameRange     '0.12.1',
+2096 silly addNameRange     '0.12.2',
+2096 silly addNameRange     '0.12.3' ] ]
+2097 verbose addNamed grunt-contrib-cssmin@0.9.0
+2098 silly addNamed semver.valid 0.9.0
+2099 silly addNamed semver.validRange 0.9.0
+2100 silly addNameRange number 2 { name: 'cookie-parser', range: '>=1.0.1 <1.1.0', hasData: true }
+2101 silly addNameRange versions [ 'cookie-parser',
+2101 silly addNameRange   [ '1.0.0',
+2101 silly addNameRange     '1.0.1',
+2101 silly addNameRange     '1.1.0',
+2101 silly addNameRange     '1.2.0',
+2101 silly addNameRange     '1.3.0',
+2101 silly addNameRange     '1.3.1',
+2101 silly addNameRange     '1.3.2',
+2101 silly addNameRange     '1.3.3',
+2101 silly addNameRange     '1.3.4',
+2101 silly addNameRange     '1.3.5' ] ]
+2102 verbose addNamed cookie-parser@1.0.1
+2103 silly addNamed semver.valid 1.0.1
+2104 silly addNamed semver.validRange 1.0.1
+2105 silly addNameRange number 2 { name: 'jit-grunt', range: '>=0.5.0 <0.6.0', hasData: true }
+2106 silly addNameRange versions [ 'jit-grunt',
+2106 silly addNameRange   [ '0.0.1',
+2106 silly addNameRange     '0.1.0',
+2106 silly addNameRange     '0.1.1',
+2106 silly addNameRange     '0.1.2',
+2106 silly addNameRange     '0.2.0',
+2106 silly addNameRange     '0.2.1',
+2106 silly addNameRange     '0.2.2',
+2106 silly addNameRange     '0.2.3',
+2106 silly addNameRange     '0.3.0',
+2106 silly addNameRange     '0.3.1',
+2106 silly addNameRange     '0.3.2',
+2106 silly addNameRange     '0.4.0',
+2106 silly addNameRange     '0.4.1',
+2106 silly addNameRange     '0.4.2',
+2106 silly addNameRange     '0.5.0',
+2106 silly addNameRange     '0.6.0',
+2106 silly addNameRange     '0.7.0',
+2106 silly addNameRange     '0.7.1',
+2106 silly addNameRange     '0.8.0',
+2106 silly addNameRange     '0.9.0',
+2106 silly addNameRange     '0.9.1' ] ]
+2107 verbose addNamed jit-grunt@0.5.0
+2108 silly addNamed semver.valid 0.5.0
+2109 silly addNamed semver.validRange 0.5.0
+2110 silly addNameTag next cb for passport-google-oauth with tag latest
+2111 verbose addNamed passport-google-oauth@0.2.0
+2112 silly addNamed semver.valid 0.2.0
+2113 silly addNamed semver.validRange 0.2.0
+2114 silly addNameRange number 2 { name: 'grunt-nodemon', range: '>=0.2.0 <0.3.0', hasData: true }
+2115 silly addNameRange versions [ 'grunt-nodemon',
+2115 silly addNameRange   [ '0.0.0',
+2115 silly addNameRange     '0.0.1',
+2115 silly addNameRange     '0.0.2',
+2115 silly addNameRange     '0.0.3',
+2115 silly addNameRange     '0.0.4',
+2115 silly addNameRange     '0.0.5',
+2115 silly addNameRange     '0.0.6',
+2115 silly addNameRange     '0.0.7',
+2115 silly addNameRange     '0.0.8',
+2115 silly addNameRange     '0.0.9',
+2115 silly addNameRange     '0.0.10',
+2115 silly addNameRange     '0.1.0',
+2115 silly addNameRange     '0.1.1',
+2115 silly addNameRange     '0.1.2',
+2115 silly addNameRange     '0.2.0',
+2115 silly addNameRange     '0.2.1',
+2115 silly addNameRange     '0.3.0',
+2115 silly addNameRange     '0.4.0' ] ]
+2116 verbose addNamed grunt-nodemon@0.2.1
+2117 silly addNamed semver.valid 0.2.1
+2118 silly addNamed semver.validRange 0.2.1
+2119 silly addNameRange number 2 { name: 'grunt-contrib-jade',
+2119 silly addNameRange   range: '>=0.11.0 <0.12.0',
+2119 silly addNameRange   hasData: true }
+2120 silly addNameRange versions [ 'grunt-contrib-jade',
+2120 silly addNameRange   [ '0.2.0',
+2120 silly addNameRange     '0.3.0',
+2120 silly addNameRange     '0.3.1',
+2120 silly addNameRange     '0.4.0',
+2120 silly addNameRange     '0.5.0',
+2120 silly addNameRange     '0.5.1',
+2120 silly addNameRange     '0.6.0',
+2120 silly addNameRange     '0.7.0',
+2120 silly addNameRange     '0.8.0',
+2120 silly addNameRange     '0.9.0',
+2120 silly addNameRange     '0.9.1',
+2120 silly addNameRange     '0.4.0-rc7',
+2120 silly addNameRange     '0.10.0',
+2120 silly addNameRange     '0.11.0',
+2120 silly addNameRange     '0.12.0',
+2120 silly addNameRange     '0.13.0',
+2120 silly addNameRange     '0.14.0',
+2120 silly addNameRange     '0.14.1',
+2120 silly addNameRange     '0.15.0' ] ]
+2121 verbose addNamed grunt-contrib-jade@0.11.0
+2122 silly addNamed semver.valid 0.11.0
+2123 silly addNamed semver.validRange 0.11.0
+2124 http fetch 200 https://registry.npmjs.org/xml-to-json/-/xml-to-json-0.1.1.tgz
+2125 http fetch 200 https://registry.npmjs.org/fs-finder/-/fs-finder-1.8.1.tgz
+2126 http fetch 200 https://registry.npmjs.org/jade-browser-middleware/-/jade-browser-middleware-0.3.3.tgz
+2127 http fetch 200 https://registry.npmjs.org/grunt-docker/-/grunt-docker-0.0.10.tgz
+2128 silly addNameRange number 2 { name: 'karma-ng-scenario',
+2128 silly addNameRange   range: '>=0.1.0 <0.2.0',
+2128 silly addNameRange   hasData: true }
+2129 silly addNameRange versions [ 'karma-ng-scenario', [ '0.0.1', '0.0.2', '0.1.0' ] ]
+2130 verbose addNamed karma-ng-scenario@0.1.0
+2131 silly addNamed semver.valid 0.1.0
+2132 silly addNamed semver.validRange 0.1.0
+2133 silly addNameRange number 2 { name: 'open', range: '>=0.0.4 <0.1.0', hasData: true }
+2134 silly addNameRange versions [ 'open', [ '0.0.0', '0.0.2', '0.0.3', '0.0.4', '0.0.5' ] ]
+2135 verbose addNamed open@0.0.5
+2136 silly addNamed semver.valid 0.0.5
+2137 silly addNamed semver.validRange 0.0.5
+2138 silly addNameRange number 2 { name: 'karma-ng-jade2js-preprocessor',
+2138 silly addNameRange   range: '>=0.1.2 <0.2.0',
+2138 silly addNameRange   hasData: true }
+2139 silly addNameRange versions [ 'karma-ng-jade2js-preprocessor',
+2139 silly addNameRange   [ '0.1.0', '0.1.1', '0.1.2', '0.1.3', '0.1.4', '0.1.5', '0.2.0' ] ]
+2140 verbose addNamed karma-ng-jade2js-preprocessor@0.1.5
+2141 silly addNamed semver.valid 0.1.5
+2142 silly addNamed semver.validRange 0.1.5
+2143 silly addNameRange number 2 { name: 'karma-coffee-preprocessor',
+2143 silly addNameRange   range: '>=0.2.1 <0.3.0',
+2143 silly addNameRange   hasData: true }
+2144 silly addNameRange versions [ 'karma-coffee-preprocessor',
+2144 silly addNameRange   [ '0.0.1',
+2144 silly addNameRange     '0.0.2',
+2144 silly addNameRange     '0.0.3',
+2144 silly addNameRange     '0.0.4',
+2144 silly addNameRange     '0.1.0',
+2144 silly addNameRange     '0.1.1',
+2144 silly addNameRange     '0.1.2',
+2144 silly addNameRange     '0.1.3',
+2144 silly addNameRange     '0.2.0',
+2144 silly addNameRange     '0.2.1',
+2144 silly addNameRange     '0.3.0' ] ]
+2145 verbose addNamed karma-coffee-preprocessor@0.2.1
+2146 silly addNamed semver.valid 0.2.1
+2147 silly addNamed semver.validRange 0.2.1
+2148 silly addNameRange number 2 { name: 'composable-middleware',
+2148 silly addNameRange   range: '>=0.3.0 <0.4.0',
+2148 silly addNameRange   hasData: true }
+2149 silly addNameRange versions [ 'composable-middleware', [ '0.1.0', '0.2.0', '0.3.0' ] ]
+2150 verbose addNamed composable-middleware@0.3.0
+2151 silly addNamed semver.valid 0.3.0
+2152 silly addNamed semver.validRange 0.3.0
+2153 silly addNameRange number 2 { name: 'grunt-ng-annotate',
+2153 silly addNameRange   range: '>=0.2.3 <0.3.0',
+2153 silly addNameRange   hasData: true }
+2154 silly addNameRange versions [ 'grunt-ng-annotate',
+2154 silly addNameRange   [ '0.0.1',
+2154 silly addNameRange     '0.0.2',
+2154 silly addNameRange     '0.0.4',
+2154 silly addNameRange     '0.0.5',
+2154 silly addNameRange     '0.0.6',
+2154 silly addNameRange     '0.0.7',
+2154 silly addNameRange     '0.0.8',
+2154 silly addNameRange     '0.1.0',
+2154 silly addNameRange     '0.2.0',
+2154 silly addNameRange     '0.2.1',
+2154 silly addNameRange     '0.2.2',
+2154 silly addNameRange     '0.2.3',
+2154 silly addNameRange     '0.3.0',
+2154 silly addNameRange     '0.3.1',
+2154 silly addNameRange     '0.3.2',
+2154 silly addNameRange     '0.4.0',
+2154 silly addNameRange     '0.5.0',
+2154 silly addNameRange     '0.6.0',
+2154 silly addNameRange     '0.7.0',
+2154 silly addNameRange     '0.8.0',
+2154 silly addNameRange     '0.9.0',
+2154 silly addNameRange     '0.9.1',
+2154 silly addNameRange     '0.9.2',
+2154 silly addNameRange     '0.10.0',
+2154 silly addNameRange     '1.0.0',
+2154 silly addNameRange     '1.0.1' ] ]
+2155 verbose addNamed grunt-ng-annotate@0.2.3
+2156 silly addNamed semver.valid 0.2.3
+2157 silly addNamed semver.validRange 0.2.3
+2158 silly addNameRange number 2 { name: 'grunt-wiredep', range: '>=1.8.0 <1.9.0', hasData: true }
+2159 silly addNameRange versions [ 'grunt-wiredep',
+2159 silly addNameRange   [ '1.7.0', '1.7.1', '1.8.0', '1.9.0', '2.0.0' ] ]
+2160 verbose addNamed grunt-wiredep@1.8.0
+2161 silly addNamed semver.valid 1.8.0
+2162 silly addNamed semver.validRange 1.8.0
+2163 silly addNameRange number 2 { name: 'grunt-open', range: '>=0.2.3 <0.3.0', hasData: true }
+2164 silly addNameRange versions [ 'grunt-open',
+2164 silly addNameRange   [ '0.1.0', '0.2.0', '0.2.1', '0.2.2', '0.2.3' ] ]
+2165 verbose addNamed grunt-open@0.2.3
+2166 silly addNamed semver.valid 0.2.3
+2167 silly addNamed semver.validRange 0.2.3
+2168 silly addNameRange number 2 { name: 'grunt-env', range: '>=0.4.1 <0.5.0', hasData: true }
+2169 silly addNameRange versions [ 'grunt-env',
+2169 silly addNameRange   [ '0.1.0',
+2169 silly addNameRange     '0.2.0',
+2169 silly addNameRange     '0.2.1',
+2169 silly addNameRange     '0.3.0',
+2169 silly addNameRange     '0.4.0',
+2169 silly addNameRange     '0.4.1',
+2169 silly addNameRange     '0.4.2',
+2169 silly addNameRange     '0.4.3',
+2169 silly addNameRange     '0.4.4' ] ]
+2170 verbose addNamed grunt-env@0.4.4
+2171 silly addNamed semver.valid 0.4.4
+2172 silly addNamed semver.validRange 0.4.4
+2173 silly addNameRange number 2 { name: 'karma-jasmine', range: '>=0.1.5 <0.2.0', hasData: true }
+2174 silly addNameRange versions [ 'karma-jasmine',
+2174 silly addNameRange   [ '0.0.1',
+2174 silly addNameRange     '0.0.2',
+2174 silly addNameRange     '0.0.3',
+2174 silly addNameRange     '0.1.0',
+2174 silly addNameRange     '0.1.1',
+2174 silly addNameRange     '0.1.2',
+2174 silly addNameRange     '0.1.3',
+2174 silly addNameRange     '0.1.4',
+2174 silly addNameRange     '0.1.5',
+2174 silly addNameRange     '0.2.0',
+2174 silly addNameRange     '0.2.1',
+2174 silly addNameRange     '0.2.2',
+2174 silly addNameRange     '0.2.3',
+2174 silly addNameRange     '0.3.0',
+2174 silly addNameRange     '0.3.1',
+2174 silly addNameRange     '0.3.2',
+2174 silly addNameRange     '0.3.3',
+2174 silly addNameRange     '0.3.4',
+2174 silly addNameRange     '0.3.5',
+2174 silly addNameRange     '0.3.6',
+2174 silly addNameRange     '0.1.6' ] ]
+2175 verbose addNamed karma-jasmine@0.1.6
+2176 silly addNamed semver.valid 0.1.6
+2177 silly addNamed semver.validRange 0.1.6
+2178 silly addNameRange number 2 { name: 'karma-ng-html2js-preprocessor',
+2178 silly addNameRange   range: '>=0.1.0 <0.2.0',
+2178 silly addNameRange   hasData: true }
+2179 silly addNameRange versions [ 'karma-ng-html2js-preprocessor',
+2179 silly addNameRange   [ '0.0.1', '0.0.2', '0.0.3', '0.0.4', '0.1.0', '0.1.1', '0.1.2' ] ]
+2180 verbose addNamed karma-ng-html2js-preprocessor@0.1.2
+2181 silly addNamed semver.valid 0.1.2
+2182 silly addNamed semver.validRange 0.1.2
+2183 silly addNameRange number 2 { name: 'grunt-newer', range: '>=0.7.0 <0.8.0', hasData: true }
+2184 silly addNameRange versions [ 'grunt-newer',
+2184 silly addNameRange   [ '0.1.0',
+2184 silly addNameRange     '0.2.0',
+2184 silly addNameRange     '0.3.1',
+2184 silly addNameRange     '0.4.0',
+2184 silly addNameRange     '0.4.1',
+2184 silly addNameRange     '0.5.0',
+2184 silly addNameRange     '0.5.1',
+2184 silly addNameRange     '0.5.2',
+2184 silly addNameRange     '0.5.3',
+2184 silly addNameRange     '0.5.4',
+2184 silly addNameRange     '0.6.0',
+2184 silly addNameRange     '0.6.1',
+2184 silly addNameRange     '0.7.0',
+2184 silly addNameRange     '0.8.0',
+2184 silly addNameRange     '1.0.0',
+2184 silly addNameRange     '1.1.0',
+2184 silly addNameRange     '1.1.1' ] ]
+2185 verbose addNamed grunt-newer@0.7.0
+2186 silly addNamed semver.valid 0.7.0
+2187 silly addNamed semver.validRange 0.7.0
+2188 silly addNameRange number 2 { name: 'grunt-asset-injector',
+2188 silly addNameRange   range: '>=0.1.0 <0.2.0',
+2188 silly addNameRange   hasData: true }
+2189 silly addNameRange versions [ 'grunt-asset-injector', [ '0.1.0' ] ]
+2190 verbose addNamed grunt-asset-injector@0.1.0
+2191 silly addNamed semver.valid 0.1.0
+2192 silly addNamed semver.validRange 0.1.0
+2193 silly addNameRange number 2 { name: 'karma-firefox-launcher',
+2193 silly addNameRange   range: '>=0.1.3 <0.2.0',
+2193 silly addNameRange   hasData: true }
+2194 silly addNameRange versions [ 'karma-firefox-launcher',
+2194 silly addNameRange   [ '0.0.1',
+2194 silly addNameRange     '0.0.2',
+2194 silly addNameRange     '0.0.3',
+2194 silly addNameRange     '0.1.0',
+2194 silly addNameRange     '0.1.1',
+2194 silly addNameRange     '0.1.2',
+2194 silly addNameRange     '0.1.3',
+2194 silly addNameRange     '0.1.4',
+2194 silly addNameRange     '0.1.5',
+2194 silly addNameRange     '0.1.6' ] ]
+2195 verbose addNamed karma-firefox-launcher@0.1.6
+2196 silly addNamed semver.valid 0.1.6
+2197 silly addNamed semver.validRange 0.1.6
+2198 silly addNameRange number 2 { name: 'fs-extra', range: '>=0.18.2 <0.19.0', hasData: true }
+2199 silly addNameRange versions [ 'fs-extra',
+2199 silly addNameRange   [ '0.0.1',
+2199 silly addNameRange     '0.0.11',
+2199 silly addNameRange     '0.0.3',
+2199 silly addNameRange     '0.0.4',
+2199 silly addNameRange     '0.1.0',
+2199 silly addNameRange     '0.1.1',
+2199 silly addNameRange     '0.1.2',
+2199 silly addNameRange     '0.1.3',
+2199 silly addNameRange     '0.2.0',
+2199 silly addNameRange     '0.2.1',
+2199 silly addNameRange     '0.3.0',
+2199 silly addNameRange     '0.3.1',
+2199 silly addNameRange     '0.3.2',
+2199 silly addNameRange     '0.4.0',
+2199 silly addNameRange     '0.5.0',
+2199 silly addNameRange     '0.6.0',
+2199 silly addNameRange     '0.6.1',
+2199 silly addNameRange     '0.6.2',
+2199 silly addNameRange     '0.6.3',
+2199 silly addNameRange     '0.6.4',
+2199 silly addNameRange     '0.7.0',
+2199 silly addNameRange     '0.7.1',
+2199 silly addNameRange     '0.8.0',
+2199 silly addNameRange     '0.8.1',
+2199 silly addNameRange     '0.9.0',
+2199 silly addNameRange     '0.9.1',
+2199 silly addNameRange     '0.10.0',
+2199 silly addNameRange     '0.11.0',
+2199 silly addNameRange     '0.11.1',
+2199 silly addNameRange     '0.12.0',
+2199 silly addNameRange     '0.13.0',
+2199 silly addNameRange     '0.14.0',
+2199 silly addNameRange     '0.15.0',
+2199 silly addNameRange     '0.16.0',
+2199 silly addNameRange     '0.16.1',
+2199 silly addNameRange     '0.16.2',
+2199 silly addNameRange     '0.16.3',
+2199 silly addNameRange     '0.16.4',
+2199 silly addNameRange     '0.16.5',
+2199 silly addNameRange     '0.17.0',
+2199 silly addNameRange     '0.18.0',
+2199 silly addNameRange     '0.18.1',
+2199 silly addNameRange     '0.18.2',
+2199 silly addNameRange     '0.18.3',
+2199 silly addNameRange     '0.18.4',
+2199 silly addNameRange     '0.19.0',
+2199 silly addNameRange     '0.20.0',
+2199 silly addNameRange     '0.20.1',
+2199 silly addNameRange     '0.21.0',
+2199 silly addNameRange     '0.22.0',
+2199 silly addNameRange     '0.22.1' ] ]
+2200 verbose addNamed fs-extra@0.18.4
+2201 silly addNamed semver.valid 0.18.4
+2202 silly addNamed semver.validRange 0.18.4
+2203 silly addNameRange number 2 { name: 'karma-html2js-preprocessor',
+2203 silly addNameRange   range: '>=0.1.0 <0.2.0',
+2203 silly addNameRange   hasData: true }
+2204 silly addNameRange versions [ 'karma-html2js-preprocessor', [ '0.0.1', '0.0.2', '0.1.0' ] ]
+2205 verbose addNamed karma-html2js-preprocessor@0.1.0
+2206 silly addNamed semver.valid 0.1.0
+2207 silly addNamed semver.validRange 0.1.0
+2208 silly addNameRange number 2 { name: 'requirejs', range: '>=2.1.11 <2.2.0', hasData: true }
+2209 silly addNameRange versions [ 'requirejs',
+2209 silly addNameRange   [ '0.26.0',
+2209 silly addNameRange     '0.27.0',
+2209 silly addNameRange     '0.27.1',
+2209 silly addNameRange     '1.0.0',
+2209 silly addNameRange     '1.0.1',
+2209 silly addNameRange     '1.0.2',
+2209 silly addNameRange     '1.0.3',
+2209 silly addNameRange     '1.0.4',
+2209 silly addNameRange     '1.0.5',
+2209 silly addNameRange     '1.0.6',
+2209 silly addNameRange     '1.0.7',
+2209 silly addNameRange     '1.0.8',
+2209 silly addNameRange     '2.0.0',
+2209 silly addNameRange     '2.0.1',
+2209 silly addNameRange     '2.0.2',
+2209 silly addNameRange     '2.0.3',
+2209 silly addNameRange     '2.0.4',
+2209 silly addNameRange     '2.0.5',
+2209 silly addNameRange     '2.0.6',
+2209 silly addNameRange     '2.1.0',
+2209 silly addNameRange     '2.1.1',
+2209 silly addNameRange     '2.1.2',
+2209 silly addNameRange     '2.1.3',
+2209 silly addNameRange     '2.1.4',
+2209 silly addNameRange     '2.1.5',
+2209 silly addNameRange     '2.1.6',
+2209 silly addNameRange     '2.1.7',
+2209 silly addNameRange     '2.1.8',
+2209 silly addNameRange     '2.1.9',
+2209 silly addNameRange     '2.1.10',
+2209 silly addNameRange     '2.1.11',
+2209 silly addNameRange     '2.1.12',
+2209 silly addNameRange     '2.1.13',
+2209 silly addNameRange     '2.1.14',
+2209 silly addNameRange     '2.1.15',
+2209 silly addNameRange     '2.1.16',
+2209 silly addNameRange     '2.1.17',
+2209 silly addNameRange     '2.1.18',
+2209 silly addNameRange     '2.1.19' ] ]
+2210 verbose addNamed requirejs@2.1.19
+2211 silly addNamed semver.valid 2.1.19
+2212 silly addNamed semver.validRange 2.1.19
+2213 silly addNameTag next cb for passport-facebook with tag latest
+2214 verbose addNamed passport-facebook@2.0.0
+2215 silly addNamed semver.valid 2.0.0
+2216 silly addNamed semver.validRange 2.0.0
+2217 silly addNameRange number 2 { name: 'grunt-usemin', range: '>=2.1.1 <2.2.0', hasData: true }
+2218 silly addNameRange versions [ 'grunt-usemin',
+2218 silly addNameRange   [ '0.1.0',
+2218 silly addNameRange     '0.1.1',
+2218 silly addNameRange     '0.1.2',
+2218 silly addNameRange     '0.1.5',
+2218 silly addNameRange     '0.1.6',
+2218 silly addNameRange     '0.1.7',
+2218 silly addNameRange     '0.1.8',
+2218 silly addNameRange     '0.1.9',
+2218 silly addNameRange     '0.1.4',
+2218 silly addNameRange     '0.1.10',
+2218 silly addNameRange     '0.1.11',
+2218 silly addNameRange     '0.1.12',
+2218 silly addNameRange     '0.1.13',
+2218 silly addNameRange     '2.0.0',
+2218 silly addNameRange     '2.0.1',
+2218 silly addNameRange     '2.0.2',
+2218 silly addNameRange     '2.1.0',
+2218 silly addNameRange     '2.1.1',
+2218 silly addNameRange     '2.2.0',
+2218 silly addNameRange     '2.3.0',
+2218 silly addNameRange     '2.4.0',
+2218 silly addNameRange     '2.5.0',
+2218 silly addNameRange     '2.5.1',
+2218 silly addNameRange     '2.6.0',
+2218 silly addNameRange     '2.6.1',
+2218 silly addNameRange     '2.6.2',
+2218 silly addNameRange     '3.0.0' ] ]
+2219 verbose addNamed grunt-usemin@2.1.1
+2220 silly addNamed semver.valid 2.1.1
+2221 silly addNamed semver.validRange 2.1.1
+2222 silly addNameRange number 2 { name: 'connect-mongo', range: '>=0.4.1 <0.5.0', hasData: true }
+2223 silly addNameRange versions [ 'connect-mongo',
+2223 silly addNameRange   [ '0.1.0',
+2223 silly addNameRange     '0.1.1',
+2223 silly addNameRange     '0.1.2',
+2223 silly addNameRange     '0.1.3',
+2223 silly addNameRange     '0.1.4',
+2223 silly addNameRange     '0.1.5',
+2223 silly addNameRange     '0.1.6',
+2223 silly addNameRange     '0.1.7',
+2223 silly addNameRange     '0.1.8',
+2223 silly addNameRange     '0.1.9',
+2223 silly addNameRange     '0.2.0',
+2223 silly addNameRange     '0.3.0',
+2223 silly addNameRange     '0.3.1',
+2223 silly addNameRange     '0.3.2',
+2223 silly addNameRange     '0.3.3',
+2223 silly addNameRange     '0.4.0',
+2223 silly addNameRange     '0.4.1',
+2223 silly addNameRange     '0.4.2',
+2223 silly addNameRange     '0.5.0',
+2223 silly addNameRange     '0.5.1',
+2223 silly addNameRange     '0.5.2',
+2223 silly addNameRange     '0.5.3',
+2223 silly addNameRange     '0.6.0',
+2223 silly addNameRange     '0.7.0',
+2223 silly addNameRange     '0.8.0',
+2223 silly addNameRange     '0.8.1',
+2223 silly addNameRange     '0.8.2',
+2223 silly addNameRange     '1.0.0-beta.1' ] ]
+2224 verbose addNamed connect-mongo@0.4.2
+2225 silly addNamed semver.valid 0.4.2
+2226 silly addNamed semver.validRange 0.4.2
+2227 silly addNameRange number 2 { name: 'grunt-contrib-uglify',
+2227 silly addNameRange   range: '>=0.4.0 <0.5.0',
+2227 silly addNameRange   hasData: true }
+2228 silly addNameRange versions [ 'grunt-contrib-uglify',
+2228 silly addNameRange   [ '0.1.0',
+2228 silly addNameRange     '0.1.1',
+2228 silly addNameRange     '0.1.2',
+2228 silly addNameRange     '0.2.0',
+2228 silly addNameRange     '0.2.1',
+2228 silly addNameRange     '0.2.2',
+2228 silly addNameRange     '0.2.3',
+2228 silly addNameRange     '0.2.4',
+2228 silly addNameRange     '0.2.5',
+2228 silly addNameRange     '0.2.6',
+2228 silly addNameRange     '0.2.7',
+2228 silly addNameRange     '0.3.0',
+2228 silly addNameRange     '0.3.1',
+2228 silly addNameRange     '0.1.1-rc5',
+2228 silly addNameRange     '0.1.1-rc6',
+2228 silly addNameRange     '0.3.2',
+2228 silly addNameRange     '0.3.3',
+2228 silly addNameRange     '0.4.0',
+2228 silly addNameRange     '0.5.0',
+2228 silly addNameRange     '0.4.1',
+2228 silly addNameRange     '0.5.1',
+2228 silly addNameRange     '0.6.0',
+2228 silly addNameRange     '0.7.0',
+2228 silly addNameRange     '0.8.0',
+2228 silly addNameRange     '0.8.1',
+2228 silly addNameRange     '0.9.0',
+2228 silly addNameRange     '0.9.1' ] ]
+2229 verbose addNamed grunt-contrib-uglify@0.4.1
+2230 silly addNamed semver.valid 0.4.1
+2231 silly addNamed semver.validRange 0.4.1
+2232 silly addNameRange number 2 { name: 'compression', range: '>=1.0.1 <1.1.0', hasData: true }
+2233 silly addNameRange versions [ 'compression',
+2233 silly addNameRange   [ '1.0.0',
+2233 silly addNameRange     '1.0.1',
+2233 silly addNameRange     '1.0.2',
+2233 silly addNameRange     '1.0.3',
+2233 silly addNameRange     '1.0.4',
+2233 silly addNameRange     '1.0.5',
+2233 silly addNameRange     '1.0.6',
+2233 silly addNameRange     '1.0.7',
+2233 silly addNameRange     '1.0.8',
+2233 silly addNameRange     '1.0.9',
+2233 silly addNameRange     '1.0.10',
+2233 silly addNameRange     '1.0.11',
+2233 silly addNameRange     '1.1.0',
+2233 silly addNameRange     '1.1.1',
+2233 silly addNameRange     '1.1.2',
+2233 silly addNameRange     '1.2.0',
+2233 silly addNameRange     '1.2.1',
+2233 silly addNameRange     '1.2.2',
+2233 silly addNameRange     '1.3.0',
+2233 silly addNameRange     '1.3.1',
+2233 silly addNameRange     '1.4.0',
+2233 silly addNameRange     '1.4.1',
+2233 silly addNameRange     '1.4.2',
+2233 silly addNameRange     '1.4.3',
+2233 silly addNameRange     '1.4.4',
+2233 silly addNameRange     '1.5.0',
+2233 silly addNameRange     '1.5.1' ] ]
+2234 verbose addNamed compression@1.0.11
+2235 silly addNamed semver.valid 1.0.11
+2236 silly addNamed semver.validRange 1.0.11
+2237 silly addNameRange number 2 { name: 'karma-requirejs',
+2237 silly addNameRange   range: '>=0.2.1 <0.3.0',
+2237 silly addNameRange   hasData: true }
+2238 silly addNameRange versions [ 'karma-requirejs',
+2238 silly addNameRange   [ '0.0.1', '0.0.2', '0.0.3', '0.1.0', '0.2.0', '0.2.1', '0.2.2' ] ]
+2239 verbose addNamed karma-requirejs@0.2.2
+2240 silly addNamed semver.valid 0.2.2
+2241 silly addNamed semver.validRange 0.2.2
+2242 silly addNameTag next cb for passport-twitter with tag latest
+2243 verbose addNamed passport-twitter@1.0.3
+2244 silly addNamed semver.valid 1.0.3
+2245 silly addNamed semver.validRange 1.0.3
+2246 silly addNameRange number 2 { name: 'chokidar', range: '>=1.0.3 <2.0.0', hasData: true }
+2247 silly addNameRange versions [ 'chokidar',
+2247 silly addNameRange   [ '0.1.1',
+2247 silly addNameRange     '0.2.0',
+2247 silly addNameRange     '0.2.1',
+2247 silly addNameRange     '0.2.2',
+2247 silly addNameRange     '0.2.3',
+2247 silly addNameRange     '0.2.4',
+2247 silly addNameRange     '0.2.5',
+2247 silly addNameRange     '0.2.6',
+2247 silly addNameRange     '0.3.0',
+2247 silly addNameRange     '0.4.0',
+2247 silly addNameRange     '0.5.0',
+2247 silly addNameRange     '0.5.1',
+2247 silly addNameRange     '0.5.2',
+2247 silly addNameRange     '0.5.3',
+2247 silly addNameRange     '0.6.0',
+2247 silly addNameRange     '0.6.1',
+2247 silly addNameRange     '0.6.2',
+2247 silly addNameRange     '0.6.3',
+2247 silly addNameRange     '0.7.0',
+2247 silly addNameRange     '0.7.1',
+2247 silly addNameRange     '0.8.0',
+2247 silly addNameRange     '0.8.1',
+2247 silly addNameRange     '0.8.2',
+2247 silly addNameRange     '0.8.3',
+2247 silly addNameRange     '0.8.4',
+2247 silly addNameRange     '0.9.0',
+2247 silly addNameRange     '0.10.0',
+2247 silly addNameRange     '0.10.1',
+2247 silly addNameRange     '0.10.2',
+2247 silly addNameRange     '0.10.3',
+2247 silly addNameRange     '0.10.4',
+2247 silly addNameRange     '0.10.5',
+2247 silly addNameRange     '0.10.6',
+2247 silly addNameRange     '0.10.7',
+2247 silly addNameRange     '0.10.8',
+2247 silly addNameRange     '0.10.9',
+2247 silly addNameRange     '0.11.0',
+2247 silly addNameRange     '0.11.1',
+2247 silly addNameRange     '0.12.0',
+2247 silly addNameRange     '0.12.1',
+2247 silly addNameRange     '0.12.2',
+2247 silly addNameRange     '0.12.3',
+2247 silly addNameRange     '0.12.4',
+2247 silly addNameRange     '0.12.5',
+2247 silly addNameRange     '0.12.6',
+2247 silly addNameRange     '1.0.0-rc1',
+2247 silly addNameRange     '1.0.0-rc1.1',
+2247 silly addNameRange     '1.0.0-rc2',
+2247 silly addNameRange     '1.0.0-rc3',
+2247 silly addNameRange     '1.0.0-rc4',
+2247 silly addNameRange     '1.0.0-rc5',
+2247 silly addNameRange     '1.0.0',
+2247 silly addNameRange     '1.0.1',
+2247 silly addNameRange     '1.0.2',
+2247 silly addNameRange     '1.0.3',
+2247 silly addNameRange     '1.0.4',
+2247 silly addNameRange     '1.0.5' ] ]
+2248 verbose addNamed chokidar@1.0.5
+2249 silly addNamed semver.valid 1.0.5
+2250 silly addNamed semver.validRange 1.0.5
+2251 silly addNameRange number 2 { name: 'grunt-svgmin', range: '>=0.4.0 <0.5.0', hasData: true }
+2252 silly addNameRange versions [ 'grunt-svgmin',
+2252 silly addNameRange   [ '0.1.0',
+2252 silly addNameRange     '0.2.0',
+2252 silly addNameRange     '0.2.1',
+2252 silly addNameRange     '0.3.0',
+2252 silly addNameRange     '0.3.1',
+2252 silly addNameRange     '0.4.0',
+2252 silly addNameRange     '1.0.0',
+2252 silly addNameRange     '2.0.0',
+2252 silly addNameRange     '2.0.1' ] ]
+2253 verbose addNamed grunt-svgmin@0.4.0
+2254 silly addNamed semver.valid 0.4.0
+2255 silly addNamed semver.validRange 0.4.0
+2256 silly addNameRange number 2 { name: 'grunt-contrib-clean',
+2256 silly addNameRange   range: '>=0.5.0 <0.6.0',
+2256 silly addNameRange   hasData: true }
+2257 silly addNameRange versions [ 'grunt-contrib-clean',
+2257 silly addNameRange   [ '0.1.0',
+2257 silly addNameRange     '0.2.0',
+2257 silly addNameRange     '0.3.0',
+2257 silly addNameRange     '0.3.1',
+2257 silly addNameRange     '0.3.2',
+2257 silly addNameRange     '0.4.0',
+2257 silly addNameRange     '0.4.1',
+2257 silly addNameRange     '0.5.0',
+2257 silly addNameRange     '0.6.0',
+2257 silly addNameRange     '0.4.0-a',
+2257 silly addNameRange     '0.4.0-rc5',
+2257 silly addNameRange     '0.4.0-rc6' ] ]
+2258 verbose addNamed grunt-contrib-clean@0.5.0
+2259 silly addNamed semver.valid 0.5.0
+2260 silly addNamed semver.validRange 0.5.0
+2261 http 200 https://registry.npmjs.org/karma
+2262 silly get cb [ 200,
+2262 silly get   { server: 'CouchDB/1.5.0 (Erlang OTP/R16B03)',
+2262 silly get     etag: '"D7D8RKZ2GAWT3I5KLBWWRJAE8"',
+2262 silly get     'content-type': 'application/json',
+2262 silly get     'cache-control': 'max-age=60',
+2262 silly get     'content-length': '926354',
+2262 silly get     'accept-ranges': 'bytes',
+2262 silly get     date: 'Thu, 23 Jul 2015 17:45:58 GMT',
+2262 silly get     via: '1.1 varnish',
+2262 silly get     age: '0',
+2262 silly get     connection: 'keep-alive',
+2262 silly get     'x-served-by': 'cache-lax1422-LAX',
+2262 silly get     'x-cache': 'HIT',
+2262 silly get     'x-cache-hits': '1',
+2262 silly get     'x-timer': 'S1437673558.484961,VS0,VE84',
+2262 silly get     vary: 'Accept' } ]
+2263 verbose get saving karma to C:\Users\Owner\AppData\Roaming\npm-cache\registry.npmjs.org\karma\.cache.json
+2264 silly mapToRegistry name karma-jasmine
+2265 silly mapToRegistry using default registry
+2266 silly mapToRegistry registry https://registry.npmjs.org/
+2267 silly mapToRegistry uri https://registry.npmjs.org/karma-jasmine
+2268 verbose addRemoteTarball https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.6.tgz not in flight; adding
+2269 verbose addRemoteTarball [ 'https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.6.tgz',
+2269 verbose addRemoteTarball   '30545057698ebdcbc63132d47be125b75b2fbc55' ]
+2270 silly mapToRegistry name requirejs
+2271 silly mapToRegistry using default registry
+2272 silly mapToRegistry registry https://registry.npmjs.org/
+2273 silly mapToRegistry uri https://registry.npmjs.org/requirejs
+2274 verbose addRemoteTarball https://registry.npmjs.org/requirejs/-/requirejs-2.1.19.tgz not in flight; adding
+2275 verbose addRemoteTarball [ 'https://registry.npmjs.org/requirejs/-/requirejs-2.1.19.tgz',
+2275 verbose addRemoteTarball   'bad50434d2d0612dc7770eea1a2e0cf87542a0f5' ]
+2276 silly addNameRange number 2 { name: 'time-grunt', range: '>=0.3.1 <0.4.0', hasData: true }
+2277 silly addNameRange versions [ 'time-grunt',
+2277 silly addNameRange   [ '0.1.0',
+2277 silly addNameRange     '0.1.1',
+2277 silly addNameRange     '0.1.2',
+2277 silly addNameRange     '0.2.0',
+2277 silly addNameRange     '0.2.1',
+2277 silly addNameRange     '0.2.2',
+2277 silly addNameRange     '0.2.3',
+2277 silly addNameRange     '0.2.4',
+2277 silly addNameRange     '0.2.5',
+2277 silly addNameRange     '0.2.6',
+2277 silly addNameRange     '0.2.7',
+2277 silly addNameRange     '0.2.8',
+2277 silly addNameRange     '0.2.9',
+2277 silly addNameRange     '0.2.10',
+2277 silly addNameRange     '0.3.1',
+2277 silly addNameRange     '0.3.2',
+2277 silly addNameRange     '0.4.0',
+2277 silly addNameRange     '1.0.0',
+2277 silly addNameRange     '1.1.0',
+2277 silly addNameRange     '1.1.1',
+2277 silly addNameRange     '1.2.0',
+2277 silly addNameRange     '1.2.1' ] ]
+2278 verbose addNamed time-grunt@0.3.2
+2279 silly addNamed semver.valid 0.3.2
+2280 silly addNamed semver.validRange 0.3.2
+2281 silly addNameRange number 2 { name: 'grunt-contrib-copy',
+2281 silly addNameRange   range: '>=0.5.0 <0.6.0',
+2281 silly addNameRange   hasData: true }
+2282 silly addNameRange versions [ 'grunt-contrib-copy',
+2282 silly addNameRange   [ '0.2.0',
+2282 silly addNameRange     '0.2.1',
+2282 silly addNameRange     '0.2.2',
+2282 silly addNameRange     '0.2.3',
+2282 silly addNameRange     '0.2.4',
+2282 silly addNameRange     '0.3.0',
+2282 silly addNameRange     '0.3.1',
+2282 silly addNameRange     '0.3.2',
+2282 silly addNameRange     '0.4.0',
+2282 silly addNameRange     '0.4.1',
+2282 silly addNameRange     '0.5.0',
+2282 silly addNameRange     '0.6.0',
+2282 silly addNameRange     '0.7.0',
+2282 silly addNameRange     '0.8.0',
+2282 silly addNameRange     '0.4.0-rc7' ] ]
+2283 verbose addNamed grunt-contrib-copy@0.5.0
+2284 silly addNamed semver.valid 0.5.0
+2285 silly addNamed semver.validRange 0.5.0
+2286 silly addNameRange number 2 { name: 'supertest', range: '>=0.11.0 <0.12.0', hasData: true }
+2287 silly addNameRange versions [ 'supertest',
+2287 silly addNameRange   [ '0.0.1',
+2287 silly addNameRange     '0.1.0',
+2287 silly addNameRange     '0.1.1',
+2287 silly addNameRange     '0.1.2',
+2287 silly addNameRange     '0.2.0',
+2287 silly addNameRange     '0.3.0',
+2287 silly addNameRange     '0.3.1',
+2287 silly addNameRange     '0.4.0',
+2287 silly addNameRange     '0.4.1',
+2287 silly addNameRange     '0.4.2',
+2287 silly addNameRange     '0.5.0',
+2287 silly addNameRange     '0.5.1',
+2287 silly addNameRange     '0.6.0',
+2287 silly addNameRange     '0.6.1',
+2287 silly addNameRange     '0.7.0',
+2287 silly addNameRange     '0.7.1',
+2287 silly addNameRange     '0.8.0',
+2287 silly addNameRange     '0.8.1',
+2287 silly addNameRange     '0.8.2',
+2287 silly addNameRange     '0.8.3',
+2287 silly addNameRange     '0.9.0',
+2287 silly addNameRange     '0.9.1',
+2287 silly addNameRange     '0.9.2',
+2287 silly addNameRange     '0.10.0',
+2287 silly addNameRange     '0.11.0',
+2287 silly addNameRange     '0.12.0',
+2287 silly addNameRange     '0.12.1',
+2287 silly addNameRange     '0.13.0',
+2287 silly addNameRange     '0.14.0',
+2287 silly addNameRange     '0.15.0',
+2287 silly addNameRange     '1.0.0',
+2287 silly addNameRange     '1.0.1' ] ]
+2288 verbose addNamed supertest@0.11.0
+2289 silly addNamed semver.valid 0.11.0
+2290 silly addNamed semver.validRange 0.11.0
+2291 silly mapToRegistry name chokidar
+2292 silly mapToRegistry using default registry
+2293 silly mapToRegistry registry https://registry.npmjs.org/
+2294 silly mapToRegistry uri https://registry.npmjs.org/chokidar
+2295 verbose addRemoteTarball https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz not in flight; adding
+2296 verbose addRemoteTarball [ 'https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz',
+2296 verbose addRemoteTarball   'f29278a36e174365da56ccad488ecacce4893494' ]
+2297 info retry fetch attempt 1 at 10:46:01 AM
+2298 info attempt registry request try #1 at 10:46:01 AM
+2299 http fetch GET https://registry.npmjs.org/mongoose/-/mongoose-3.8.34.tgz
+2300 info retry fetch attempt 1 at 10:46:01 AM
+2301 info attempt registry request try #1 at 10:46:01 AM
+2302 http fetch GET https://registry.npmjs.org/promise/-/promise-7.0.3.tgz
+2303 silly addNameRange number 2 { name: 'grunt', range: '>=0.4.4 <0.5.0', hasData: true }
+2304 silly addNameRange versions [ 'grunt',
+2304 silly addNameRange   [ '0.1.0',
+2304 silly addNameRange     '0.1.1',
+2304 silly addNameRange     '0.1.2',
+2304 silly addNameRange     '0.2.0',
+2304 silly addNameRange     '0.2.1',
+2304 silly addNameRange     '0.2.2',
+2304 silly addNameRange     '0.2.3',
+2304 silly addNameRange     '0.2.4',
+2304 silly addNameRange     '0.2.5',
+2304 silly addNameRange     '0.2.6',
+2304 silly addNameRange     '0.2.7',
+2304 silly addNameRange     '0.2.8',
+2304 silly addNameRange     '0.2.9',
+2304 silly addNameRange     '0.2.10',
+2304 silly addNameRange     '0.2.11',
+2304 silly addNameRange     '0.2.12',
+2304 silly addNameRange     '0.2.13',
+2304 silly addNameRange     '0.2.14',
+2304 silly addNameRange     '0.2.15',
+2304 silly addNameRange     '0.3.0',
+2304 silly addNameRange     '0.3.1',
+2304 silly addNameRange     '0.3.2',
+2304 silly addNameRange     '0.3.3',
+2304 silly addNameRange     '0.3.4',
+2304 silly addNameRange     '0.3.5',
+2304 silly addNameRange     '0.3.6',
+2304 silly addNameRange     '0.3.7',
+2304 silly addNameRange     '0.3.8',
+2304 silly addNameRange     '0.3.9',
+2304 silly addNameRange     '0.3.10',
+2304 silly addNameRange     '0.3.11',
+2304 silly addNameRange     '0.3.12',
+2304 silly addNameRange     '0.3.13',
+2304 silly addNameRange     '0.3.14',
+2304 silly addNameRange     '0.3.15',
+2304 silly addNameRange     '0.3.16',
+2304 silly addNameRange     '0.3.17',
+2304 silly addNameRange     '0.4.0',
+2304 silly addNameRange     '0.4.1',
+2304 silly addNameRange     '0.4.2',
+2304 silly addNameRange     '0.4.3',
+2304 silly addNameRange     '0.4.4',
+2304 silly addNameRange     '0.4.5',
+2304 silly addNameRange     '0.3.13-a',
+2304 silly addNameRange     '0.4.0-a',
+2304 silly addNameRange     '0.4.0-rc1',
+2304 silly addNameRange     '0.4.0-rc2',
+2304 silly addNameRange     '0.4.0-rc3',
+2304 silly addNameRange     '0.4.0-rc4',
+2304 silly addNameRange     '0.4.0-rc5',
+2304 silly addNameRange     '0.4.0-rc6',
+2304 silly addNameRange     '0.4.0-rc7',
+2304 silly addNameRange     '0.4.0-rc8' ] ]
+2305 verbose addNamed grunt@0.4.5
+2306 silly addNamed semver.valid 0.4.5
+2307 silly addNamed semver.validRange 0.4.5
+2308 silly addNameRange number 2 { name: 'grunt-express-server',
+2308 silly addNameRange   range: '>=0.4.17 <0.5.0',
+2308 silly addNameRange   hasData: true }
+2309 silly addNameRange versions [ 'grunt-express-server',
+2309 silly addNameRange   [ '0.1.0',
+2309 silly addNameRange     '0.2.0',
+2309 silly addNameRange     '0.3.1',
+2309 silly addNameRange     '0.4.0',
+2309 silly addNameRange     '0.4.1',
+2309 silly addNameRange     '0.4.2',
+2309 silly addNameRange     '0.4.3',
+2309 silly addNameRange     '0.4.4',
+2309 silly addNameRange     '0.4.5',
+2309 silly addNameRange     '0.4.6',
+2309 silly addNameRange     '0.4.7',
+2309 silly addNameRange     '0.4.8',
+2309 silly addNameRange     '0.4.9',
+2309 silly addNameRange     '0.4.10',
+2309 silly addNameRange     '0.4.11',
+2309 silly addNameRange     '0.4.12',
+2309 silly addNameRange     '0.4.13',
+2309 silly addNameRange     '0.4.14',
+2309 silly addNameRange     '0.4.15',
+2309 silly addNameRange     '0.4.16',
+2309 silly addNameRange     '0.4.17',
+2309 silly addNameRange     '0.4.18',
+2309 silly addNameRange     '0.4.19',
+2309 silly addNameRange     '0.5.0',
+2309 silly addNameRange     '0.5.1' ] ]
+2310 verbose addNamed grunt-express-server@0.4.19
+2311 silly addNamed semver.valid 0.4.19
+2312 silly addNamed semver.validRange 0.4.19
+2313 silly addNameRange number 2 { name: 'grunt-angular-templates',
+2313 silly addNameRange   range: '>=0.5.4 <0.6.0',
+2313 silly addNameRange   hasData: true }
+2314 silly addNameRange versions [ 'grunt-angular-templates',
+2314 silly addNameRange   [ '0.1.0',
+2314 silly addNameRange     '0.1.1',
+2314 silly addNameRange     '0.1.2',
+2314 silly addNameRange     '0.1.3',
+2314 silly addNameRange     '0.2.1',
+2314 silly addNameRange     '0.2.2',
+2314 silly addNameRange     '0.3.0',
+2314 silly addNameRange     '0.3.1',
+2314 silly addNameRange     '0.3.2',
+2314 silly addNameRange     '0.3.3',
+2314 silly addNameRange     '0.3.4',
+2314 silly addNameRange     '0.3.6',
+2314 silly addNameRange     '0.3.7',
+2314 silly addNameRange     '0.3.8',
+2314 silly addNameRange     '0.3.9',
+2314 silly addNameRange     '0.3.10',
+2314 silly addNameRange     '0.3.11',
+2314 silly addNameRange     '0.3.12',
+2314 silly addNameRange     '0.4.0',
+2314 silly addNameRange     '0.4.1',
+2314 silly addNameRange     '0.4.2',
+2314 silly addNameRange     '0.4.3',
+2314 silly addNameRange     '0.4.4',
+2314 silly addNameRange     '0.4.5',
+2314 silly addNameRange     '0.4.6',
+2314 silly addNameRange     '0.4.7',
+2314 silly addNameRange     '0.4.9',
+2314 silly addNameRange     '0.5.0',
+2314 silly addNameRange     '0.4.10',
+2314 silly addNameRange     '0.5.1',
+2314 silly addNameRange     '0.5.2',
+2314 silly addNameRange     '0.5.3',
+2314 silly addNameRange     '0.5.4',
+2314 silly addNameRange     '0.5.5',
+2314 silly addNameRange     '0.5.6',
+2314 silly addNameRange     '0.5.7' ] ]
+2315 verbose addNamed grunt-angular-templates@0.5.7
+2316 silly addNamed semver.valid 0.5.7
+2317 silly addNamed semver.validRange 0.5.7
+2318 silly addNameRange number 2 { name: 'winston', range: '>=1.0.0 <2.0.0', hasData: true }
+2319 silly addNameRange versions [ 'winston',
+2319 silly addNameRange   [ '0.2.11',
+2319 silly addNameRange     '0.3.3',
+2319 silly addNameRange     '0.3.4',
+2319 silly addNameRange     '0.3.5',
+2319 silly addNameRange     '0.4.0',
+2319 silly addNameRange     '0.4.1',
+2319 silly addNameRange     '0.5.0',
+2319 silly addNameRange     '0.5.1',
+2319 silly addNameRange     '0.5.2',
+2319 silly addNameRange     '0.5.3',
+2319 silly addNameRange     '0.5.4',
+2319 silly addNameRange     '0.5.5',
+2319 silly addNameRange     '0.5.6',
+2319 silly addNameRange     '0.5.7',
+2319 silly addNameRange     '0.5.8',
+2319 silly addNameRange     '0.5.9',
+2319 silly addNameRange     '0.5.10',
+2319 silly addNameRange     '0.5.11',
+2319 silly addNameRange     '0.6.1',
+2319 silly addNameRange     '0.6.2',
+2319 silly addNameRange     '0.7.0',
+2319 silly addNameRange     '0.7.1',
+2319 silly addNameRange     '0.7.2',
+2319 silly addNameRange     '0.7.3',
+2319 silly addNameRange     '0.8.0',
+2319 silly addNameRange     '0.8.1',
+2319 silly addNameRange     '0.8.2',
+2319 silly addNameRange     '0.8.3',
+2319 silly addNameRange     '0.9.0',
+2319 silly addNameRange     '1.0.0',
+2319 silly addNameRange     '1.0.1' ] ]
+2320 verbose addNamed winston@1.0.1
+2321 silly addNamed semver.valid 1.0.1
+2322 silly addNamed semver.validRange 1.0.1
+2323 silly addNameRange number 2 { name: 'grunt-karma', range: '>=0.8.2 <0.9.0', hasData: true }
+2324 silly addNameRange versions [ 'grunt-karma',
+2324 silly addNameRange   [ '0.3.0',
+2324 silly addNameRange     '0.4.0',
+2324 silly addNameRange     '0.4.1',
+2324 silly addNameRange     '0.4.2',
+2324 silly addNameRange     '0.4.3',
+2324 silly addNameRange     '0.4.4',
+2324 silly addNameRange     '0.5.0',
+2324 silly addNameRange     '0.4.5',
+2324 silly addNameRange     '0.5.1',
+2324 silly addNameRange     '0.5.2',
+2324 silly addNameRange     '0.4.6',
+2324 silly addNameRange     '0.5.3',
+2324 silly addNameRange     '0.5.4',
+2324 silly addNameRange     '0.6.0',
+2324 silly addNameRange     '0.6.1',
+2324 silly addNameRange     '0.7.0',
+2324 silly addNameRange     '0.6.2',
+2324 silly addNameRange     '0.7.1',
+2324 silly addNameRange     '0.7.2',
+2324 silly addNameRange     '0.7.3',
+2324 silly addNameRange     '0.8.0',
+2324 silly addNameRange     '0.8.1',
+2324 silly addNameRange     '0.8.2',
+2324 silly addNameRange     '0.8.3',
+2324 silly addNameRange     '0.9.0',
+2324 silly addNameRange     '0.10.0',
+2324 silly addNameRange     '0.10.1',
+2324 silly addNameRange     '0.11.0',
+2324 silly addNameRange     '0.11.1',
+2324 silly addNameRange     '0.11.2',
+2324 silly addNameRange     '0.12.0' ] ]
+2325 verbose addNamed grunt-karma@0.8.3
+2326 silly addNamed semver.valid 0.8.3
+2327 silly addNamed semver.validRange 0.8.3
+2328 silly addNameTag next cb for grunt-contrib-stylus with tag latest
+2329 verbose addNamed grunt-contrib-stylus@0.22.0
+2330 silly addNamed semver.valid 0.22.0
+2331 silly addNamed semver.validRange 0.22.0
+2332 silly cache afterAdd express@4.0.0
+2333 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\express\4.0.0\package\package.json not in flight; writing
+2334 silly cache afterAdd express-session@1.0.4
+2335 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\express-session\1.0.4\package\package.json not in flight; writing
+2336 silly cache afterAdd jsonwebtoken@0.3.0
+2337 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jsonwebtoken\0.3.0\package\package.json not in flight; writing
+2338 silly cache afterAdd passport@0.2.2
+2339 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport\0.2.2\package\package.json not in flight; writing
+2340 silly cache afterAdd lodash@2.4.2
+2341 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\lodash\2.4.2\package\package.json not in flight; writing
+2342 silly cache afterAdd multer@0.1.8
+2343 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\multer\0.1.8\package\package.json not in flight; writing
+2344 silly cache afterAdd formidable@1.0.17
+2345 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\formidable\1.0.17\package\package.json not in flight; writing
+2346 silly cache afterAdd method-override@1.0.2
+2347 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\method-override\1.0.2\package\package.json not in flight; writing
+2348 silly cache afterAdd errorhandler@1.0.2
+2349 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\errorhandler\1.0.2\package\package.json not in flight; writing
+2350 silly cache afterAdd passport-local@0.1.6
+2351 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-local\0.1.6\package\package.json not in flight; writing
+2352 silly cache afterAdd express-jwt@0.1.4
+2353 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\express-jwt\0.1.4\package\package.json not in flight; writing
+2354 silly cache afterAdd grunt-concurrent@0.5.0
+2355 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-concurrent\0.5.0\package\package.json not in flight; writing
+2356 silly cache afterAdd mongoose-validators@0.1.0
+2357 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\mongoose-validators\0.1.0\package\package.json not in flight; writing
+2358 silly cache afterAdd serve-favicon@2.0.1
+2359 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\serve-favicon\2.0.1\package\package.json not in flight; writing
+2360 silly cache afterAdd decompress-unzip@3.3.0
+2361 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\decompress-unzip\3.3.0\package\package.json not in flight; writing
+2362 silly cache afterAdd grunt-contrib-htmlmin@0.2.0
+2363 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-htmlmin\0.2.0\package\package.json not in flight; writing
+2364 info retry fetch attempt 1 at 10:46:02 AM
+2365 info attempt registry request try #1 at 10:46:02 AM
+2366 http fetch GET https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.1.6.tgz
+2367 info retry fetch attempt 1 at 10:46:02 AM
+2368 info attempt registry request try #1 at 10:46:02 AM
+2369 http fetch GET https://registry.npmjs.org/requirejs/-/requirejs-2.1.19.tgz
+2370 silly cache afterAdd morgan@1.0.1
+2371 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\morgan\1.0.1\package\package.json not in flight; writing
+2372 silly cache afterAdd grunt-contrib-imagemin@0.7.2
+2373 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-imagemin\0.7.2\package\package.json not in flight; writing
+2374 silly addNameRange number 2 { name: 'should', range: '>=3.3.1 <3.4.0', hasData: true }
+2375 silly addNameRange versions [ 'should',
+2375 silly addNameRange   [ '0.0.1',
+2375 silly addNameRange     '0.0.2',
+2375 silly addNameRange     '0.0.3',
+2375 silly addNameRange     '0.0.4',
+2375 silly addNameRange     '0.1.0',
+2375 silly addNameRange     '0.2.0',
+2375 silly addNameRange     '0.2.1',
+2375 silly addNameRange     '0.3.0',
+2375 silly addNameRange     '0.3.1',
+2375 silly addNameRange     '0.3.2',
+2375 silly addNameRange     '0.4.0',
+2375 silly addNameRange     '0.4.1',
+2375 silly addNameRange     '0.4.2',
+2375 silly addNameRange     '0.5.0',
+2375 silly addNameRange     '0.5.1',
+2375 silly addNameRange     '0.6.0',
+2375 silly addNameRange     '0.6.1',
+2375 silly addNameRange     '0.6.2',
+2375 silly addNameRange     '0.6.3',
+2375 silly addNameRange     '1.0.0',
+2375 silly addNameRange     '1.1.0',
+2375 silly addNameRange     '1.1.1',
+2375 silly addNameRange     '1.2.0',
+2375 silly addNameRange     '1.2.1',
+2375 silly addNameRange     '1.2.2',
+2375 silly addNameRange     '1.3.0',
+2375 silly addNameRange     '2.0.0',
+2375 silly addNameRange     '2.0.1',
+2375 silly addNameRange     '2.0.2',
+2375 silly addNameRange     '2.1.0',
+2375 silly addNameRange     '2.1.1',
+2375 silly addNameRange     '3.0.0',
+2375 silly addNameRange     '3.0.1',
+2375 silly addNameRange     '3.1.0',
+2375 silly addNameRange     '3.1.1',
+2375 silly addNameRange     '3.1.2',
+2375 silly addNameRange     '3.1.3',
+2375 silly addNameRange     '3.1.4',
+2375 silly addNameRange     '3.2.0-beta1',
+2375 silly addNameRange     '3.2.0',
+2375 silly addNameRange     '3.3.0',
+2375 silly addNameRange     '3.3.1',
+2375 silly addNameRange     '3.3.2',
+2375 silly addNameRange     '4.0.0',
+2375 silly addNameRange     '4.0.1',
+2375 silly addNameRange     '4.0.3',
+2375 silly addNameRange     '4.0.4',
+2375 silly addNameRange     '4.1.0',
+2375 silly addNameRange     '4.2.0',
+2375 silly addNameRange     '4.2.1',
+2375 silly addNameRange     '4.3.0',
+2375 silly addNameRange     '4.3.1',
+2375 silly addNameRange     '4.4.0',
+2375 silly addNameRange     '4.4.1',
+2375 silly addNameRange     '4.4.2',
+2375 silly addNameRange     '4.4.3',
+2375 silly addNameRange     '4.4.4',
+2375 silly addNameRange     '4.5.0',
+2375 silly addNameRange     '4.5.1',
+2375 silly addNameRange     '4.5.2',
+2375 silly addNameRange     '4.6.0',
+2375 silly addNameRange     '4.6.1',
+2375 silly addNameRange     '4.6.2',
+2375 silly addNameRange     '4.6.3',
+2375 silly addNameRange     '4.6.4',
+2375 silly addNameRange     '4.6.5',
+2375 silly addNameRange     '5.0.0',
+2375 silly addNameRange     '5.0.1',
+2375 silly addNameRange     '5.1.0',
+2375 silly addNameRange     '5.2.0',
+2375 silly addNameRange     '6.0.0',
+2375 silly addNameRange     '6.0.1',
+2375 silly addNameRange     '6.0.2',
+2375 silly addNameRange     '6.0.3',
+2375 silly addNameRange     '7.0.0',
+2375 silly addNameRange     '7.0.1',
+2375 silly addNameRange     '7.0.2' ] ]
+2376 verbose addNamed should@3.3.2
+2377 silly addNamed semver.valid 3.3.2
+2378 silly addNamed semver.validRange 3.3.2
+2379 silly mapToRegistry name winston
+2380 silly mapToRegistry using default registry
+2381 silly mapToRegistry registry https://registry.npmjs.org/
+2382 silly mapToRegistry uri https://registry.npmjs.org/winston
+2383 verbose addRemoteTarball https://registry.npmjs.org/winston/-/winston-1.0.1.tgz not in flight; adding
+2384 verbose addRemoteTarball [ 'https://registry.npmjs.org/winston/-/winston-1.0.1.tgz',
+2384 verbose addRemoteTarball   '4c6f5a1167ebc516ac29b76e4eadb873c15289a4' ]
+2385 info retry fetch attempt 1 at 10:46:02 AM
+2386 info attempt registry request try #1 at 10:46:02 AM
+2387 http fetch GET https://registry.npmjs.org/chokidar/-/chokidar-1.0.5.tgz
+2388 silly addNameRange number 2 { name: 'grunt-contrib-watch',
+2388 silly addNameRange   range: '>=0.6.1 <0.7.0',
+2388 silly addNameRange   hasData: true }
+2389 silly addNameRange versions [ 'grunt-contrib-watch',
+2389 silly addNameRange   [ '0.1.0',
+2389 silly addNameRange     '0.1.1',
+2389 silly addNameRange     '0.1.2',
+2389 silly addNameRange     '0.1.3',
+2389 silly addNameRange     '0.1.4',
+2389 silly addNameRange     '0.2.0',
+2389 silly addNameRange     '0.3.0',
+2389 silly addNameRange     '0.3.1',
+2389 silly addNameRange     '0.4.0',
+2389 silly addNameRange     '0.4.1',
+2389 silly addNameRange     '0.4.2',
+2389 silly addNameRange     '0.4.3',
+2389 silly addNameRange     '0.4.4',
+2389 silly addNameRange     '0.5.0',
+2389 silly addNameRange     '0.5.1',
+2389 silly addNameRange     '0.5.2',
+2389 silly addNameRange     '0.5.3',
+2389 silly addNameRange     '0.6.0',
+2389 silly addNameRange     '0.6.1',
+2389 silly addNameRange     '0.2.0-a',
+2389 silly addNameRange     '0.2.0-rc5',
+2389 silly addNameRange     '0.2.0-rc7' ] ]
+2390 verbose addNamed grunt-contrib-watch@0.6.1
+2391 silly addNamed semver.valid 0.6.1
+2392 silly addNamed semver.validRange 0.6.1
+2393 silly mapToRegistry name grunt-contrib-stylus
+2394 silly mapToRegistry using default registry
+2395 silly mapToRegistry registry https://registry.npmjs.org/
+2396 silly mapToRegistry uri https://registry.npmjs.org/grunt-contrib-stylus
+2397 verbose addRemoteTarball https://registry.npmjs.org/grunt-contrib-stylus/-/grunt-contrib-stylus-0.22.0.tgz not in flight; adding
+2398 verbose addRemoteTarball [ 'https://registry.npmjs.org/grunt-contrib-stylus/-/grunt-contrib-stylus-0.22.0.tgz',
+2398 verbose addRemoteTarball   'c1577af69dcc28a1d21355ddb1f8711e3b86cb02' ]
+2399 silly cache afterAdd grunt-mocha-test@0.10.2
+2400 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-mocha-test\0.10.2\package\package.json not in flight; writing
+2401 silly cache afterAdd decompress@2.3.0
+2402 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\decompress\2.3.0\package\package.json not in flight; writing
+2403 silly cache afterAdd prerender-node@1.3.0
+2404 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\prerender-node\1.3.0\package\package.json not in flight; writing
+2405 silly cache afterAdd grunt-dom-munger@3.4.0
+2406 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-dom-munger\3.4.0\package\package.json not in flight; writing
+2407 silly cache afterAdd grunt-node-inspector@0.1.6
+2408 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-node-inspector\0.1.6\package\package.json not in flight; writing
+2409 silly cache afterAdd grunt-docco@0.3.3
+2410 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-docco\0.3.3\package\package.json not in flight; writing
+2411 silly cache afterAdd connect-livereload@0.4.1
+2412 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\connect-livereload\0.4.1\package\package.json not in flight; writing
+2413 silly cache afterAdd jshint-stylish@0.1.5
+2414 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jshint-stylish\0.1.5\package\package.json not in flight; writing
+2415 silly cache afterAdd karma-chrome-launcher@0.1.12
+2416 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-chrome-launcher\0.1.12\package\package.json not in flight; writing
+2417 silly cache afterAdd body-parser@1.5.2
+2418 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\body-parser\1.5.2\package\package.json not in flight; writing
+2419 silly cache afterAdd karma-script-launcher@0.1.0
+2420 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-script-launcher\0.1.0\package\package.json not in flight; writing
+2421 silly cache afterAdd grunt-protractor-runner@1.2.1
+2422 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-protractor-runner\1.2.1\package\package.json not in flight; writing
+2423 silly cache afterAdd karma-phantomjs-launcher@0.1.4
+2424 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-phantomjs-launcher\0.1.4\package\package.json not in flight; writing
+2425 silly cache afterAdd grunt-rev@0.1.0
+2426 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-rev\0.1.0\package\package.json not in flight; writing
+2427 silly cache afterAdd grunt-contrib-cssmin@0.9.0
+2428 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-cssmin\0.9.0\package\package.json not in flight; writing
+2429 silly cache afterAdd grunt-google-cdn@0.4.3
+2430 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-google-cdn\0.4.3\package\package.json not in flight; writing
+2431 silly cache afterAdd jit-grunt@0.5.0
+2432 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jit-grunt\0.5.0\package\package.json not in flight; writing
+2433 silly cache afterAdd karma-jade-preprocessor@0.0.11
+2434 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-jade-preprocessor\0.0.11\package\package.json not in flight; writing
+2435 silly cache afterAdd passport-google-oauth@0.2.0
+2436 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-google-oauth\0.2.0\package\package.json not in flight; writing
+2437 silly cache afterAdd jade@1.2.0
+2438 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jade\1.2.0\package\package.json not in flight; writing
+2439 silly cache afterAdd grunt-contrib-jade@0.11.0
+2440 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-jade\0.11.0\package\package.json not in flight; writing
+2441 silly cache afterAdd grunt-nodemon@0.2.1
+2442 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-nodemon\0.2.1\package\package.json not in flight; writing
+2443 silly cache afterAdd cookie-parser@1.0.1
+2444 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\cookie-parser\1.0.1\package\package.json not in flight; writing
+2445 silly cache afterAdd karma-ng-jade2js-preprocessor@0.1.5
+2446 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-ng-jade2js-preprocessor\0.1.5\package\package.json not in flight; writing
+2447 silly cache afterAdd karma-ng-scenario@0.1.0
+2448 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-ng-scenario\0.1.0\package\package.json not in flight; writing
+2449 silly cache afterAdd composable-middleware@0.3.0
+2450 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\composable-middleware\0.3.0\package\package.json not in flight; writing
+2451 silly cache afterAdd grunt-ng-annotate@0.2.3
+2452 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-ng-annotate\0.2.3\package\package.json not in flight; writing
+2453 silly cache afterAdd grunt-wiredep@1.8.0
+2454 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-wiredep\1.8.0\package\package.json not in flight; writing
+2455 silly cache afterAdd karma-ng-html2js-preprocessor@0.1.2
+2456 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-ng-html2js-preprocessor\0.1.2\package\package.json not in flight; writing
+2457 silly cache afterAdd open@0.0.5
+2458 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\open\0.0.5\package\package.json not in flight; writing
+2459 silly fetchAndShaCheck shasum 0bd54954584a011d25655de7a70674ad50bce19e
+2460 silly cache afterAdd grunt-env@0.4.4
+2461 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-env\0.4.4\package\package.json not in flight; writing
+2462 silly cache afterAdd grunt-newer@0.7.0
+2463 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-newer\0.7.0\package\package.json not in flight; writing
+2464 silly cache afterAdd grunt-asset-injector@0.1.0
+2465 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-asset-injector\0.1.0\package\package.json not in flight; writing
+2466 silly cache afterAdd karma-coffee-preprocessor@0.2.1
+2467 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-coffee-preprocessor\0.2.1\package\package.json not in flight; writing
+2468 silly cache afterAdd karma-html2js-preprocessor@0.1.0
+2469 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-html2js-preprocessor\0.1.0\package\package.json not in flight; writing
+2470 silly cache afterAdd karma-firefox-launcher@0.1.6
+2471 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-firefox-launcher\0.1.6\package\package.json not in flight; writing
+2472 silly cache afterAdd passport-facebook@2.0.0
+2473 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-facebook\2.0.0\package\package.json not in flight; writing
+2474 silly cache afterAdd grunt-usemin@2.1.1
+2475 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-usemin\2.1.1\package\package.json not in flight; writing
+2476 silly cache afterAdd fs-extra@0.18.4
+2477 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\fs-extra\0.18.4\package\package.json not in flight; writing
+2478 silly cache afterAdd grunt-contrib-uglify@0.4.1
+2479 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-uglify\0.4.1\package\package.json not in flight; writing
+2480 silly cache afterAdd karma-requirejs@0.2.2
+2481 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-requirejs\0.2.2\package\package.json not in flight; writing
+2482 silly cache afterAdd passport-twitter@1.0.3
+2483 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-twitter\1.0.3\package\package.json not in flight; writing
+2484 silly addNameRange number 2 { name: 'grunt-autoprefixer',
+2484 silly addNameRange   range: '>=0.7.2 <0.8.0',
+2484 silly addNameRange   hasData: true }
+2485 silly addNameRange versions [ 'grunt-autoprefixer',
+2485 silly addNameRange   [ '0.1.0',
+2485 silly addNameRange     '0.1.20130424',
+2485 silly addNameRange     '0.1.20130516',
+2485 silly addNameRange     '0.1.20130615',
+2485 silly addNameRange     '0.2.0',
+2485 silly addNameRange     '0.2.20130718',
+2485 silly addNameRange     '0.2.20130806',
+2485 silly addNameRange     '0.3.0',
+2485 silly addNameRange     '0.3.1',
+2485 silly addNameRange     '0.4.0',
+2485 silly addNameRange     '0.4.1',
+2485 silly addNameRange     '0.4.2',
+2485 silly addNameRange     '0.5.0',
+2485 silly addNameRange     '0.6.0',
+2485 silly addNameRange     '0.6.1',
+2485 silly addNameRange     '0.6.2',
+2485 silly addNameRange     '0.6.3',
+2485 silly addNameRange     '0.6.4',
+2485 silly addNameRange     '0.6.5',
+2485 silly addNameRange     '0.7.0',
+2485 silly addNameRange     '0.7.1',
+2485 silly addNameRange     '0.7.2',
+2485 silly addNameRange     '0.7.3',
+2485 silly addNameRange     '0.7.4',
+2485 silly addNameRange     '0.7.5',
+2485 silly addNameRange     '0.7.6',
+2485 silly addNameRange     '0.8.0',
+2485 silly addNameRange     '0.8.1',
+2485 silly addNameRange     '0.8.2',
+2485 silly addNameRange     '1.0.0',
+2485 silly addNameRange     '1.0.1',
+2485 silly addNameRange     '2.0.0',
+2485 silly addNameRange     '2.1.0',
+2485 silly addNameRange     '2.2.0',
+2485 silly addNameRange     '3.0.0',
+2485 silly addNameRange     '3.0.1',
+2485 silly addNameRange     '3.0.2',
+2485 silly addNameRange     '3.0.3' ] ]
+2486 verbose addNamed grunt-autoprefixer@0.7.6
+2487 silly addNamed semver.valid 0.7.6
+2488 silly addNamed semver.validRange 0.7.6
+2489 silly addNameRange number 2 { name: 'grunt-contrib-jshint',
+2489 silly addNameRange   range: '>=0.10.0 <0.11.0',
+2489 silly addNameRange   hasData: true }
+2490 silly addNameRange versions [ 'grunt-contrib-jshint',
+2490 silly addNameRange   [ '0.1.0',
+2490 silly addNameRange     '0.1.1',
+2490 silly addNameRange     '0.2.0',
+2490 silly addNameRange     '0.3.0',
+2490 silly addNameRange     '0.4.0',
+2490 silly addNameRange     '0.4.1',
+2490 silly addNameRange     '0.4.2',
+2490 silly addNameRange     '0.4.3',
+2490 silly addNameRange     '0.5.0',
+2490 silly addNameRange     '0.5.1',
+2490 silly addNameRange     '0.5.2',
+2490 silly addNameRange     '0.5.3',
+2490 silly addNameRange     '0.5.4',
+2490 silly addNameRange     '0.6.0',
+2490 silly addNameRange     '0.6.1',
+2490 silly addNameRange     '0.6.2',
+2490 silly addNameRange     '0.6.3',
+2490 silly addNameRange     '0.6.4',
+2490 silly addNameRange     '0.6.5',
+2490 silly addNameRange     '0.7.0',
+2490 silly addNameRange     '0.7.1',
+2490 silly addNameRange     '0.7.2',
+2490 silly addNameRange     '0.8.0',
+2490 silly addNameRange     '0.9.0',
+2490 silly addNameRange     '0.9.1',
+2490 silly addNameRange     '0.9.2',
+2490 silly addNameRange     '0.10.0',
+2490 silly addNameRange     '0.11.0',
+2490 silly addNameRange     '0.11.1',
+2490 silly addNameRange     '0.11.2',
+2490 silly addNameRange     '0.1.1-rc5',
+2490 silly addNameRange     '0.1.1-rc6' ] ]
+2491 verbose addNamed grunt-contrib-jshint@0.10.0
+2492 silly addNamed semver.valid 0.10.0
+2493 silly addNamed semver.validRange 0.10.0
+2494 silly cache afterAdd connect-mongo@0.4.2
+2495 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\connect-mongo\0.4.2\package\package.json not in flight; writing
+2496 silly cache afterAdd grunt-open@0.2.3
+2497 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-open\0.2.3\package\package.json not in flight; writing
+2498 silly cache afterAdd compression@1.0.11
+2499 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\compression\1.0.11\package\package.json not in flight; writing
+2500 silly addNameRange number 2 { name: 'gm', range: '>=1.18.1 <2.0.0', hasData: true }
+2501 silly addNameRange versions [ 'gm',
+2501 silly addNameRange   [ '0.1.1',
+2501 silly addNameRange     '0.1.2',
+2501 silly addNameRange     '0.2.0',
+2501 silly addNameRange     '0.2.1',
+2501 silly addNameRange     '0.3.0',
+2501 silly addNameRange     '0.3.1',
+2501 silly addNameRange     '0.3.2',
+2501 silly addNameRange     '0.4.0',
+2501 silly addNameRange     '0.4.1',
+2501 silly addNameRange     '0.4.2',
+2501 silly addNameRange     '0.4.3',
+2501 silly addNameRange     '0.5.0',
+2501 silly addNameRange     '0.6.0',
+2501 silly addNameRange     '1.0.0',
+2501 silly addNameRange     '1.0.1',
+2501 silly addNameRange     '1.0.2',
+2501 silly addNameRange     '1.0.3',
+2501 silly addNameRange     '1.0.4',
+2501 silly addNameRange     '1.0.5',
+2501 silly addNameRange     '1.1.0',
+2501 silly addNameRange     '1.2.0',
+2501 silly addNameRange     '1.3.0',
+2501 silly addNameRange     '1.3.1',
+2501 silly addNameRange     '1.3.2',
+2501 silly addNameRange     '1.4.0',
+2501 silly addNameRange     '1.4.1',
+2501 silly addNameRange     '1.4.2',
+2501 silly addNameRange     '1.5.0',
+2501 silly addNameRange     '1.5.1',
+2501 silly addNameRange     '1.6.0',
+2501 silly addNameRange     '1.6.1',
+2501 silly addNameRange     '1.7.0',
+2501 silly addNameRange     '1.8.0',
+2501 silly addNameRange     '1.8.1',
+2501 silly addNameRange     '1.8.2',
+2501 silly addNameRange     '1.9.0',
+2501 silly addNameRange     '1.9.1',
+2501 silly addNameRange     '1.9.2',
+2501 silly addNameRange     '1.10.0',
+2501 silly addNameRange     '1.11.0',
+2501 silly addNameRange     '1.11.1',
+2501 silly addNameRange     '1.12.0',
+2501 silly addNameRange     '1.12.1',
+2501 silly addNameRange     '1.12.2',
+2501 silly addNameRange     '1.13.0',
+2501 silly addNameRange     '1.13.1',
+2501 silly addNameRange     '1.13.2',
+2501 silly addNameRange     '1.13.3',
+2501 silly addNameRange     '1.14.0',
+2501 silly addNameRange     '1.14.1',
+2501 silly addNameRange     '1.14.2',
+2501 silly addNameRange     '1.15.0',
+2501 silly addNameRange     '1.16.0',
+2501 silly addNameRange     '1.17.0',
+2501 silly addNameRange     '1.18.1' ] ]
+2502 verbose addNamed gm@1.18.1
+2503 silly addNamed semver.valid 1.18.1
+2504 silly addNamed semver.validRange 1.18.1
+2505 silly cache afterAdd grunt-svgmin@0.4.0
+2506 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-svgmin\0.4.0\package\package.json not in flight; writing
+2507 silly cache afterAdd time-grunt@0.3.2
+2508 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\time-grunt\0.3.2\package\package.json not in flight; writing
+2509 info retry fetch attempt 1 at 10:46:02 AM
+2510 info attempt registry request try #1 at 10:46:02 AM
+2511 http fetch GET https://registry.npmjs.org/winston/-/winston-1.0.1.tgz
+2512 info retry fetch attempt 1 at 10:46:02 AM
+2513 info attempt registry request try #1 at 10:46:02 AM
+2514 http fetch GET https://registry.npmjs.org/grunt-contrib-stylus/-/grunt-contrib-stylus-0.22.0.tgz
+2515 silly cache afterAdd supertest@0.11.0
+2516 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\supertest\0.11.0\package\package.json not in flight; writing
+2517 silly cache afterAdd grunt@0.4.5
+2518 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt\0.4.5\package\package.json not in flight; writing
+2519 silly cache afterAdd grunt-contrib-copy@0.5.0
+2520 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-copy\0.5.0\package\package.json not in flight; writing
+2521 silly cache afterAdd grunt-contrib-clean@0.5.0
+2522 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-clean\0.5.0\package\package.json not in flight; writing
+2523 silly cache afterAdd grunt-express-server@0.4.19
+2524 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-express-server\0.4.19\package\package.json not in flight; writing
+2525 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\express\4.0.0\package\package.json written
+2526 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\express-session\1.0.4\package\package.json written
+2527 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jsonwebtoken\0.3.0\package\package.json written
+2528 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport\0.2.2\package\package.json written
+2529 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\formidable\1.0.17\package\package.json written
+2530 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\lodash\2.4.2\package\package.json written
+2531 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\multer\0.1.8\package\package.json written
+2532 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\method-override\1.0.2\package\package.json written
+2533 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\errorhandler\1.0.2\package\package.json written
+2534 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\express-jwt\0.1.4\package\package.json written
+2535 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-concurrent\0.5.0\package\package.json written
+2536 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\serve-favicon\2.0.1\package\package.json written
+2537 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\mongoose-validators\0.1.0\package\package.json written
+2538 silly fetchAndShaCheck shasum 0594c1ad03d1653b79d080ca330177e5e20a7072
+2539 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\decompress-unzip\3.3.0\package\package.json written
+2540 verbose addTmpTarball C:\Users\Owner\AppData\Local\Temp\npm-4924-94edbaf0\registry.npmjs.org\mongoose-text-search\-\mongoose-text-search-0.0.2.tgz not in flight; adding
+2541 verbose addTmpTarball already have metadata; skipping unpack for mongoose-text-search@0.0.2
+2542 silly addNameRange number 2 { name: 'karma', range: '>=0.12.9 <0.13.0', hasData: true }
+2543 silly addNameRange versions [ 'karma',
+2543 silly addNameRange   [ '0.8.0',
+2543 silly addNameRange     '0.9.0-dart',
+2543 silly addNameRange     '0.8.1',
+2543 silly addNameRange     '0.8.2',
+2543 silly addNameRange     '0.8.3',
+2543 silly addNameRange     '0.9.0',
+2543 silly addNameRange     '0.8.4',
+2543 silly addNameRange     '0.9.1',
+2543 silly addNameRange     '0.8.5',
+2543 silly addNameRange     '0.9.2',
+2543 silly addNameRange     '0.9.2-dart',
+2543 silly addNameRange     '0.9.3',
+2543 silly addNameRange     '0.8.6',
+2543 silly addNameRange     '0.9.4',
+2543 silly addNameRange     '0.8.7',
+2543 silly addNameRange     '0.9.5',
+2543 silly addNameRange     '0.9.6',
+2543 silly addNameRange     '0.8.8',
+2543 silly addNameRange     '0.9.7',
+2543 silly addNameRange     '0.9.8',
+2543 silly addNameRange     '0.10.0',
+2543 silly addNameRange     '0.10.1',
+2543 silly addNameRange     '0.10.2',
+2543 silly addNameRange     '0.11.0',
+2543 silly addNameRange     '0.11.1',
+2543 silly addNameRange     '0.10.3',
+2543 silly addNameRange     '0.10.4',
+2543 silly addNameRange     '0.11.2',
+2543 silly addNameRange     '0.11.3',
+2543 silly addNameRange     '0.10.5',
+2543 silly addNameRange     '0.11.4',
+2543 silly addNameRange     '0.11.5',
+2543 silly addNameRange     '0.10.6',
+2543 silly addNameRange     '0.11.6',
+2543 silly addNameRange     '0.10.7',
+2543 silly addNameRange     '0.11.7',
+2543 silly addNameRange     '0.11.8',
+2543 silly addNameRange     '0.11.9',
+2543 silly addNameRange     '0.10.8',
+2543 silly addNameRange     '0.11.10',
+2543 silly addNameRange     '0.11.11',
+2543 silly addNameRange     '0.11.12',
+2543 silly addNameRange     '0.11.11-dev',
+2543 silly addNameRange     '0.10.9',
+2543 silly addNameRange     '0.11.12-dev',
+2543 silly addNameRange     '0.11.12-dev2',
+2543 silly addNameRange     '0.11.13',
+2543 silly addNameRange     '0.11.14',
+2543 silly addNameRange     '0.12.0',
+2543 silly addNameRange     '0.10.10',
+2543 silly addNameRange     '0.12.1',
+2543 silly addNameRange     '0.12.2',
+2543 silly addNameRange     '0.12.3',
+2543 silly addNameRange     '0.12.4',
+2543 silly addNameRange     '0.12.5',
+2543 silly addNameRange     '0.12.6',
+2543 silly addNameRange     '0.12.6-beta-43e6e28',
+2543 silly addNameRange     '0.12.7',
+2543 silly addNameRange     '0.12.8',
+2543 silly addNameRange     '0.12.9',
+2543 silly addNameRange     '0.12.10',
+2543 silly addNameRange     '0.12.11',
+2543 silly addNameRange     '0.12.12',
+2543 silly addNameRange     '0.12.11-beta-3029418',
+2543 silly addNameRange     '0.12.13',
+2543 silly addNameRange     '0.12.14',
+2543 silly addNameRange     '0.12.15',
+2543 silly addNameRange     '0.12.16',
+2543 silly addNameRange     '0.12.16-beta-905422d',
+2543 silly addNameRange     '0.12.17',
+2543 silly addNameRange     '0.12.18',
+2543 silly addNameRange     '0.12.19',
+2543 silly addNameRange     '0.12.20',
+2543 silly addNameRange     '0.12.21',
+2543 silly addNameRange     '0.12.22',
+2543 silly addNameRange     '0.12.23',
+2543 silly addNameRange     '0.12.24',
+2543 silly addNameRange     '0.12.24-beta-6cf7955',
+2543 silly addNameRange     '0.12.25',
+2543 silly addNameRange     '0.12.25-beta-37a7958',
+2543 silly addNameRange     '0.12.25-beta-ad5bc24',
+2543 silly addNameRange     '0.12.26',
+2543 silly addNameRange     '0.12.27',
+2543 silly addNameRange     '0.12.28',
+2543 silly addNameRange     '0.12.28-beta-b9be580',
+2543 silly addNameRange     '0.12.29',
+2543 silly addNameRange     '0.12.30',
+2543 silly addNameRange     '0.12.31',
+2543 silly addNameRange     '0.12.28-beta-f65c864',
+2543 silly addNameRange     '0.12.24-dev-test',
+2543 silly addNameRange     '0.12.24-dev-socketio10',
+2543 silly addNameRange     '0.12.24-dev-socketio10-2',
+2543 silly addNameRange     '0.12.32-beta.0',
+2543 silly addNameRange     '0.12.32',
+2543 silly addNameRange     '0.13.0-rc.0',
+2543 silly addNameRange     '0.12.33',
+2543 silly addNameRange     '0.13.0-rc.1',
+2543 silly addNameRange     '0.12.34',
+2543 silly addNameRange     '0.13.0-rc.2',
+2543 silly addNameRange     '0.12.35',
+2543 silly addNameRange     '0.13.0-rc.3',
+2543 silly addNameRange     '0.12.36',
+2543 silly addNameRange     '0.13.0-rc.4',
+2543 silly addNameRange     '0.12.37',
+2543 silly addNameRange     '0.13.0-rc.5',
+2543 silly addNameRange     '0.13.0-rc.6',
+2543 silly addNameRange     '0.13.0-rc.7',
+2543 silly addNameRange     '0.13.0-rc.8',
+2543 silly addNameRange     '0.13.0-rc.9',
+2543 silly addNameRange     '0.13.0',
+2543 silly addNameRange     '0.13.1',
+2543 silly addNameRange     '0.13.2',
+2543 silly addNameRange     '0.13.3' ] ]
+2544 verbose addNamed karma@0.12.37
+2545 silly addNamed semver.valid 0.12.37
+2546 silly addNamed semver.validRange 0.12.37
+2547 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-htmlmin\0.2.0\package\package.json written
+2548 silly cache afterAdd grunt-angular-templates@0.5.7
+2549 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-angular-templates\0.5.7\package\package.json not in flight; writing
+2550 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-imagemin\0.7.2\package\package.json written
+2551 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\morgan\1.0.1\package\package.json written
+2552 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-mocha-test\0.10.2\package\package.json written
+2553 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-local\0.1.6\package\package.json written
+2554 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\decompress\2.3.0\package\package.json written
+2555 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-dom-munger\3.4.0\package\package.json written
+2556 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-node-inspector\0.1.6\package\package.json written
+2557 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\connect-livereload\0.4.1\package\package.json written
+2558 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\prerender-node\1.3.0\package\package.json written
+2559 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-docco\0.3.3\package\package.json written
+2560 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jshint-stylish\0.1.5\package\package.json written
+2561 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-script-launcher\0.1.0\package\package.json written
+2562 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\body-parser\1.5.2\package\package.json written
+2563 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-rev\0.1.0\package\package.json written
+2564 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-chrome-launcher\0.1.12\package\package.json written
+2565 silly mapToRegistry name karma
+2566 silly mapToRegistry using default registry
+2567 silly mapToRegistry registry https://registry.npmjs.org/
+2568 silly mapToRegistry uri https://registry.npmjs.org/karma
+2569 verbose addRemoteTarball https://registry.npmjs.org/karma/-/karma-0.12.37.tgz not in flight; adding
+2570 verbose addRemoteTarball [ 'https://registry.npmjs.org/karma/-/karma-0.12.37.tgz',
+2570 verbose addRemoteTarball   '1a9f7fdeccd69de2e835e04edbac2ecd3fa645e4' ]
+2571 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-cssmin\0.9.0\package\package.json written
+2572 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-google-cdn\0.4.3\package\package.json written
+2573 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-phantomjs-launcher\0.1.4\package\package.json written
+2574 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jit-grunt\0.5.0\package\package.json written
+2575 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-jade-preprocessor\0.0.11\package\package.json written
+2576 silly cache afterAdd grunt-contrib-watch@0.6.1
+2577 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-watch\0.6.1\package\package.json not in flight; writing
+2578 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-protractor-runner\1.2.1\package\package.json written
+2579 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jade\1.2.0\package\package.json written
+2580 silly cache afterAdd grunt-karma@0.8.3
+2581 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-karma\0.8.3\package\package.json not in flight; writing
+2582 silly cache afterAdd should@3.3.2
+2583 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\should\3.3.2\package\package.json not in flight; writing
+2584 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-jade\0.11.0\package\package.json written
+2585 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-google-oauth\0.2.0\package\package.json written
+2586 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\cookie-parser\1.0.1\package\package.json written
+2587 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-ng-jade2js-preprocessor\0.1.5\package\package.json written
+2588 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-nodemon\0.2.1\package\package.json written
+2589 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\composable-middleware\0.3.0\package\package.json written
+2590 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-ng-scenario\0.1.0\package\package.json written
+2591 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-ng-annotate\0.2.3\package\package.json written
+2592 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-wiredep\1.8.0\package\package.json written
+2593 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-ng-html2js-preprocessor\0.1.2\package\package.json written
+2594 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\open\0.0.5\package\package.json written
+2595 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-env\0.4.4\package\package.json written
+2596 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-newer\0.7.0\package\package.json written
+2597 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-asset-injector\0.1.0\package\package.json written
+2598 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-coffee-preprocessor\0.2.1\package\package.json written
+2599 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-facebook\2.0.0\package\package.json written
+2600 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-html2js-preprocessor\0.1.0\package\package.json written
+2601 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-firefox-launcher\0.1.6\package\package.json written
+2602 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\fs-extra\0.18.4\package\package.json written
+2603 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\karma-requirejs\0.2.2\package\package.json written
+2604 http fetch 200 https://registry.npmjs.org/mongoose/-/mongoose-3.8.34.tgz
+2605 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-uglify\0.4.1\package\package.json written
+2606 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\passport-twitter\1.0.3\package\package.json written
+2607 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-usemin\2.1.1\package\package.json written
+2608 verbose addTmpTarball C:\Users\Owner\AppData\Local\Temp\npm-4924-94edbaf0\registry.npmjs.org\jade-browser-middleware\-\jade-browser-middleware-0.3.3.tgz not in flight; adding
+2609 verbose addTmpTarball already have metadata; skipping unpack for jade-browser-middleware@0.3.3
+2610 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-open\0.2.3\package\package.json written
+2611 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\connect-mongo\0.4.2\package\package.json written
+2612 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-svgmin\0.4.0\package\package.json written
+2613 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\supertest\0.11.0\package\package.json written
+2614 info retry fetch attempt 1 at 10:46:02 AM
+2615 info attempt registry request try #1 at 10:46:02 AM
+2616 http fetch GET https://registry.npmjs.org/karma/-/karma-0.12.37.tgz
+2617 silly cache afterAdd grunt-autoprefixer@0.7.6
+2618 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-autoprefixer\0.7.6\package\package.json not in flight; writing
+2619 silly cache afterAdd grunt-contrib-jshint@0.10.0
+2620 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-jshint\0.10.0\package\package.json not in flight; writing
+2621 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\time-grunt\0.3.2\package\package.json written
+2622 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-copy\0.5.0\package\package.json written
+2623 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-clean\0.5.0\package\package.json written
+2624 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt\0.4.5\package\package.json written
+2625 silly cache afterAdd gm@1.18.1
+2626 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\gm\1.18.1\package\package.json not in flight; writing
+2627 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-angular-templates\0.5.7\package\package.json written
+2628 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\compression\1.0.11\package\package.json written
+2629 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-express-server\0.4.19\package\package.json written
+2630 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-watch\0.6.1\package\package.json written
+2631 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-karma\0.8.3\package\package.json written
+2632 silly fetchAndShaCheck shasum 106fea8aa89d0af343360663d5855862cae1b874
+2633 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\should\3.3.2\package\package.json written
+2634 silly cache afterAdd mongoose-text-search@0.0.2
+2635 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\mongoose-text-search\0.0.2\package\package.json not in flight; writing
+2636 silly fetchAndShaCheck shasum 1f01b3cc02c5c33a3d057342218bb91d961b622e
+2637 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-contrib-jshint\0.10.0\package\package.json written
+2638 verbose addTmpTarball C:\Users\Owner\AppData\Local\Temp\npm-4924-94edbaf0\registry.npmjs.org\fs-finder\-\fs-finder-1.8.1.tgz not in flight; adding
+2639 verbose addTmpTarball already have metadata; skipping unpack for fs-finder@1.8.1
+2640 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\gm\1.18.1\package\package.json written
+2641 verbose addTmpTarball C:\Users\Owner\AppData\Local\Temp\npm-4924-94edbaf0\registry.npmjs.org\xml-to-json\-\xml-to-json-0.1.1.tgz not in flight; adding
+2642 verbose addTmpTarball already have metadata; skipping unpack for xml-to-json@0.1.1
+2643 silly cache afterAdd jade-browser-middleware@0.3.3
+2644 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jade-browser-middleware\0.3.3\package\package.json not in flight; writing
+2645 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-autoprefixer\0.7.6\package\package.json written
+2646 silly fetchAndShaCheck shasum 5ea38b08601e77a76ad756f9b0dd86eed68f4fe3
+2647 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\jade-browser-middleware\0.3.3\package\package.json written
+2648 verbose addTmpTarball C:\Users\Owner\AppData\Local\Temp\npm-4924-94edbaf0\registry.npmjs.org\grunt-docker\-\grunt-docker-0.0.10.tgz not in flight; adding
+2649 verbose addTmpTarball already have metadata; skipping unpack for grunt-docker@0.0.10
+2650 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\mongoose-text-search\0.0.2\package\package.json written
+2651 silly cache afterAdd fs-finder@1.8.1
+2652 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\fs-finder\1.8.1\package\package.json not in flight; writing
+2653 silly cache afterAdd xml-to-json@0.1.1
+2654 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\xml-to-json\0.1.1\package\package.json not in flight; writing
+2655 silly cache afterAdd grunt-docker@0.0.10
+2656 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-docker\0.0.10\package\package.json not in flight; writing
+2657 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\xml-to-json\0.1.1\package\package.json written
+2658 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\fs-finder\1.8.1\package\package.json written
+2659 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\grunt-docker\0.0.10\package\package.json written
+2660 http fetch 200 https://registry.npmjs.org/promise/-/promise-7.0.3.tgz
+2661 silly fetchAndShaCheck shasum 1c467fdea4cbb2564357e6e90fcc9d559066d66f
+2662 verbose addTmpTarball C:\Users\Owner\AppData\Local\Temp\npm-4924-94edbaf0\registry.npmjs.org\promise\-\promise-7.0.3.tgz not in flight; adding
+2663 verbose addTmpTarball already have metadata; skipping unpack for promise@7.0.3
+2664 silly cache afterAdd promise@7.0.3
+2665 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\promise\7.0.3\package\package.json not in flight; writing
+2666 verbose afterAdd C:\Users\Owner\AppData\Roaming\npm-cache\promise\7.0.3\package\package.json written
+2667 verbose stack TypeError: Cannot read property 'trim' of undefined
+2667 verbose stack     at C:\Program Files\nodejs\node_modules\npm\lib\cache\add-remote-git.js:98:31
+2667 verbose stack     at C:\Program Files\nodejs\node_modules\npm\lib\utils\git.js:50:14
+2667 verbose stack     at F (C:\Program Files\nodejs\node_modules\npm\node_modules\which\which.js:40:25)
+2667 verbose stack     at E (C:\Program Files\nodejs\node_modules\npm\node_modules\which\which.js:43:29)
+2667 verbose stack     at C:\Program Files\nodejs\node_modules\npm\node_modules\which\which.js:54:16
+2667 verbose stack     at FSReqWrap.oncomplete (fs.js:95:15)
+2668 verbose cwd C:\Users\Owner\Documents\GitHub\FULLSTACK\backend\MEAN\meanbase-1.0.0
+2669 error Windows_NT 6.3.9600
+2670 error argv "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install"
+2671 error node v0.12.2
+2672 error npm  v2.7.4
+2673 error Cannot read property 'trim' of undefined
+2674 error If you need help, you may report this error at:
+2674 error     <https://github.com/npm/npm/issues>
+2675 verbose exit [ 1, true ]

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "connect-livereload": "~0.4.0",
     "grunt": "~0.4.4",
+    "load-grunt-tasks": "^0.4.0",
     "grunt-angular-templates": "^0.5.4",
     "grunt-asset-injector": "^0.1.0",
     "grunt-autoprefixer": "~0.7.2",


### PR DESCRIPTION
A quick restructure of the build tasks to make meanbase less mean to new developers.
The goal is to break up each task so it is easier to debug and maintain.

Note that grunt/angular.js and imagemin.js may not work and may need to be rewritten so they can contain 2-3 tasks.